### PR TITLE
Updated the code to create session only if the recipient is not the node initiating the flow

### DIFF
--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/MoveToken.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/MoveToken.kt
@@ -2,6 +2,7 @@ package com.r3.corda.sdk.token.workflow.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.sdk.token.contracts.commands.MoveTokenCommand
+import com.r3.corda.sdk.token.contracts.types.TokenPointer
 import com.r3.corda.sdk.token.contracts.types.TokenType
 import com.r3.corda.sdk.token.contracts.utilities.withNotary
 import com.r3.corda.sdk.token.workflow.selection.TokenSelection
@@ -40,7 +41,11 @@ object MoveToken {
             val owningParty: AbstractParty = if (anonymous) {
                 subFlow(RequestConfidentialIdentity.Initiator(ownerSession)).party.anonymise()
             } else owner
-
+    
+            if (ownedToken is TokenPointer<*>) {
+                subFlow(AddPartyToDistributionList(owner, ownedToken.pointer.pointer))
+            }
+            
             val (builder, keys) = if (amount == null) {
                 // The assumption here is that there is only one owned token of a particular type at any one time.
                 // Double clarify this in the docs to ensure that it is used properly. Either way, this code likely

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateEvolvableToken.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateEvolvableToken.kt
@@ -33,7 +33,11 @@ class UpdateEvolvableToken(
         val stx: SignedTransaction = serviceHub.signInitialTransaction(utx)
         // Get the list of parties on the distribution list for this evolvable token.
         val updateSubscribers: List<DistributionRecord> = getDistributionList(serviceHub, new.linearId)
-        val sessions = updateSubscribers.map { initiateFlow(it.party) }
+        // If the token is self-issued, subscribers list will contain ourIdentity.
+        // Remove ourIdentity to avoid initiating a session to itself.
+        val filteredList = updateSubscribers.filter { it.party != ourIdentity }
+    
+        val sessions = filteredList.map { initiateFlow(it.party) }
         // Send to all on the list. This could take a while if there are many subscribers!
         return subFlow(FinalityFlow(transaction = stx, sessions = sessions))
     }

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateEvolvableToken.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateEvolvableToken.kt
@@ -37,8 +37,11 @@ class UpdateEvolvableToken(
         // Remove ourIdentity to avoid initiating a session to itself.
         val filteredList = updateSubscribers.filter { it.party != ourIdentity }
     
-        val sessions = filteredList.map { initiateFlow(it.party) }
-        // Send to all on the list. This could take a while if there are many subscribers!
-        return subFlow(FinalityFlow(transaction = stx, sessions = sessions))
+        return if(filteredList.isNotEmpty()){
+            val sessions = filteredList.map { initiateFlow(it.party) }
+            // Send to all on the list. This could take a while if there are many subscribers!
+            subFlow(FinalityFlow(transaction = stx, sessions = sessions))
+        } else
+            subFlow(FinalityFlow(transaction = stx, sessions = emptyList()))
     }
 }

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenFlowTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenFlowTests.kt
@@ -6,10 +6,12 @@ import com.r3.corda.sdk.token.money.GBP
 import com.r3.corda.sdk.token.workflow.statesAndContracts.House
 import com.r3.corda.sdk.token.workflow.utilities.getDistributionList
 import com.r3.corda.sdk.token.workflow.utilities.getLinearStateById
+import com.r3.corda.sdk.token.workflow.utilities.tokenBalance
 import net.corda.core.contracts.LinearState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.node.services.queryBy
 import net.corda.core.utilities.getOrThrow
+import net.corda.finance.AMOUNT
 import net.corda.testing.node.StartedMockNode
 import org.junit.Before
 import org.junit.Test
@@ -140,5 +142,43 @@ class TokenFlowTests : MockNetworkTest(numberOfNodes = 3) {
         val issueTokenB = I.issueTokens(housePointer, A, NOTARY, 50 of housePointer).getOrThrow()
         A.watchForTransaction(issueTokenB.id).toCompletableFuture().getOrThrow()
     }
-
+    
+    @Test
+    fun `create evolvable token, then self issue`() {
+        //This is to test the self issue flow, as the counter party session is not created
+        val house = House("24 Leinster Gardens, Bayswater, London", 900_000.GBP, listOf(I.legalIdentity()))
+        val createTokenTx = I.createEvolvableToken(house, NOTARY.legalIdentity()).getOrThrow()
+        val houseToken: StateAndRef<House> = createTokenTx.singleOutput()
+        val housePointer: TokenPointer<House> = house.toPointer()
+        I.issueTokens(housePointer, I, NOTARY,  1000 of housePointer).getOrThrow()
+        val houseTokenState = I.services.vaultService.queryBy<House>().states.single()
+        assertEquals(houseToken, houseTokenState)
+        val moveTokenTx = I.moveTokens(housePointer, A, 250 of housePointer, anonymous = true).getOrThrow()
+        A.watchForTransaction(moveTokenTx.id).getOrThrow()
+        val issuerTokenBalance = I.services.vaultService.tokenBalance(housePointer)
+        assertEquals(issuerTokenBalance, AMOUNT(750, housePointer))
+        val aPartyTokenBalance = A.services.vaultService.tokenBalance(housePointer)
+        assertEquals(aPartyTokenBalance, AMOUNT(250, housePointer))
+    }
+    
+    @Test
+    fun `create evolvable token, then self issue, move and update`() {
+        //This is to test the self issue flow, as the counter party session is not created
+        val house = House("24 Leinster Gardens, Bayswater, London", 900_000.GBP, listOf(I.legalIdentity()))
+        val createTokenTx = I.createEvolvableToken(house, NOTARY.legalIdentity()).getOrThrow()
+        val houseToken: StateAndRef<House> = createTokenTx.singleOutput()
+        val housePointer: TokenPointer<House> = house.toPointer()
+        I.issueTokens(housePointer, I, NOTARY,  1000 of housePointer).getOrThrow()
+        val houseTokenState = I.services.vaultService.queryBy<House>().states.single()
+        assertEquals(houseToken, houseTokenState)
+        val moveTokenTx = I.moveTokens(housePointer, A, 250 of housePointer, anonymous = true).getOrThrow()
+        A.watchForTransaction(moveTokenTx.id).getOrThrow()
+        val proposedToken = house.copy(valuation = 950_000.GBP)
+        val updateTx = I.updateEvolvableToken(houseToken, proposedToken).getOrThrow()
+        A.watchForTransaction(updateTx.id).getOrThrow()
+        val houseQuery= A.services.vaultService.queryBy<House>().states
+        val updatedHouse = houseQuery.single().state.data
+        assertEquals(updatedHouse.valuation, proposedToken.valuation)
+    }
+    
 }

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenFlowTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenFlowTests.kt
@@ -180,5 +180,4 @@ class TokenFlowTests : MockNetworkTest(numberOfNodes = 3) {
         val updatedHouse = houseQuery.single().state.data
         assertEquals(updatedHouse.valuation, proposedToken.valuation)
     }
-    
 }


### PR DESCRIPTION
1. IssueToken -> Checked and created the session only if the node running the flow is different from the owner. Please check whether I have created owningParty correctly in case if anonymous is set to true
2. UpdateEvolvableToken -> Filtered the updateSubscribers list in case if the node running the flow is part of the updateSubscribers list. This will happen, if we have self-issued token.
3.  MoveToken -> When a token is transferred to a party, I felt that new party should be added to the distribution list hence added a subflow AddPartyToDistributionList. If this is not needed, please let me know.
