### PR TITLE
Changed single to singleOrNull when checking that issuer is sole signer of an issuance

### DIFF
--- a/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/FungibleTokenContract.kt
+++ b/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/FungibleTokenContract.kt
@@ -57,7 +57,7 @@ open class FungibleTokenContract : AbstractTokenContract<FungibleToken<TokenType
             // the line below should never fail on single().
             val issuer = map { it.amount.token.issuer }.toSet().single()
             // Only the issuer should be signing the issuer command.
-            require(issuer.owningKey == issueCommand.signers.single()) {
+            require(issueCommand.signers.singleOrNull { it == issuer.owningKey } != null) {
                 "The issuer must be the only signing party when an amount of tokens are issued."
             }
         }


### PR DESCRIPTION
When `issueCommand.signers` contains more than one element, calling
`single` will throw an `IllegalArgumentException("List has more than one element.")`
which translates to `TransactionVerificationException.ContractRejection`
being thrown.

Without this fix, [this](https://github.com/corda/token-sdk/blob/2a8d9199b07baea554d49b8fe2937b927b7b4ce0/contract/src/test/kotlin/com/r3/corda/sdk/token/contracts/FungibleTokenTests.kt#L81) assertion fails
<br>
_I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org/)._
