### PR TITLE
Issue and Move flows can take AbstractParty

### DIFF
--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/ConfidentialIssueMoveFlows.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/ConfidentialIssueMoveFlows.kt
@@ -1,0 +1,62 @@
+package com.r3.corda.sdk.token.workflow.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.sdk.token.contracts.types.TokenType
+import net.corda.core.contracts.Amount
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+
+object ConfidentialIssueFlow {
+    @InitiatingFlow
+    class Initiator<T : TokenType>(
+            val token: T,
+            val holder: Party,
+            val notary: Party,
+            val amount: Amount<T>? = null
+    ) : FlowLogic<SignedTransaction>() {
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val holderSession = initiateFlow(holder)
+            val confidentialHolder = subFlow(RequestConfidentialIdentity.Initiator(holderSession)).party.anonymise()
+            return subFlow(IssueToken.Initiator(token, confidentialHolder, notary, amount, holderSession))
+        }
+    }
+
+    @InitiatedBy(Initiator::class)
+    class Responder(val otherSession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            subFlow(RequestConfidentialIdentity.Responder(otherSession))
+            subFlow(IssueToken.Responder(otherSession))
+        }
+    }
+}
+
+object ConfidentialMoveFlow {
+    @InitiatingFlow
+    class Initiator<T : TokenType>(
+            val ownedToken: T,
+            val holder: Party,
+            val amount: Amount<T>? = null
+    ) : FlowLogic<SignedTransaction>() {
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val holderSession = initiateFlow(holder)
+            val confidentialHolder = subFlow(RequestConfidentialIdentity.Initiator(holderSession)).party.anonymise()
+            return subFlow(MoveToken.Initiator(ownedToken, confidentialHolder, amount, holderSession))
+        }
+    }
+
+    @InitiatedBy(Initiator::class)
+    class Responder(val otherSession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            subFlow(RequestConfidentialIdentity.Responder(otherSession))
+            subFlow(MoveToken.Responder(otherSession))
+        }
+    }
+}

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/RedeemToken.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/RedeemToken.kt
@@ -1,7 +1,6 @@
 package com.r3.corda.sdk.token.workflow.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import com.r3.corda.sdk.token.contracts.commands.MoveTokenCommand
 import com.r3.corda.sdk.token.contracts.states.AbstractToken
 import com.r3.corda.sdk.token.contracts.states.FungibleToken
 import com.r3.corda.sdk.token.contracts.states.NonFungibleToken

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/DiamondWithTokenScenarioTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/DiamondWithTokenScenarioTests.kt
@@ -50,7 +50,7 @@ class DiamondWithTokenScenarioTests : MockNetworkTest("Gemological Institute of 
         val diamondPointer = publishedDiamond.state.data.toPointer<DiamondCertificate.State>()
         val issueTokenTx = denise.issueTokens(
                 token = diamondPointer,
-                owner = alice,
+                issueTo = alice,
                 notary = NOTARY,
                 anonymous = true
         ).getOrThrow()


### PR DESCRIPTION
Extracted RequestConfidentialIdentity out of these flows, so now it's
possible to pass AbstractParty as new token owner.