### PR TITLE
Bump version to 5.0-SNAPSHOT to experiment with shell serialisers.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0'
+        corda_release_version = '5.0-SNAPSHOT'
         corda_gradle_plugins_version = '4.0.42'
         aetherVersion = '1.0.0.v20140518'
         mavenVersion = '3.1.0'
@@ -66,6 +66,8 @@ subprojects {
         mavenCentral()
         mavenLocal()
         maven { url 'https://jitpack.io' }
+        maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda' }
+        // TODO: Remove this when we depend on Corda 4.1.
         maven { url "http://ci-artifactory.corda.r3cev.com/artifactory/corda-dev" }
         maven { url "http://ci-artifactory.corda.r3cev.com/artifactory/corda-releases" }
     }

--- a/contract/build.gradle
+++ b/contract/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "junit:junit:$junit_version"
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
-    testCompile "junit:junit:$junit_version"
     testCompile project(":modules:money")
 }
 

--- a/modules/money/build.gradle
+++ b/modules/money/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
+    cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
 
     // Logging.
     testCompile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"

--- a/workflow/build.gradle
+++ b/workflow/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     }
 }
 
-
 apply plugin: 'kotlin-jpa'
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.cordapp'
@@ -67,7 +66,6 @@ dependencies {
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
     testCompile "junit:junit:$junit_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "junit:junit:$junit_version"
 
     // CorDapp dependencies.
     cordapp project(":contract")


### PR DESCRIPTION
* Bump version to 5.0-SNAPSHOT to experiment with shell serialisers.
* Add a dependency on node-api to the money module so we can write some custom deserialisers. This is hopefully only temporary.
* Cleaned up dupe dependencies.
