### PR TITLE
MoveToken should update subscriptions

### DIFF
--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/MoveToken.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/MoveToken.kt
@@ -5,8 +5,6 @@ import com.r3.corda.sdk.token.contracts.types.TokenPointer
 import com.r3.corda.sdk.token.contracts.types.TokenType
 import com.r3.corda.sdk.token.workflow.selection.TokenSelection
 import com.r3.corda.sdk.token.workflow.selection.generateMoveNonFungible
-import com.r3.corda.sdk.token.workflow.utilities.ownedTokenAmountCriteria
-import com.r3.corda.sdk.token.workflow.utilities.tokenAmountWithIssuerCriteria
 import net.corda.core.contracts.Amount
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
@@ -16,20 +14,17 @@ import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.ReceiveFinalityFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.AbstractParty
-import net.corda.core.identity.Party
 import net.corda.core.node.StatesToRecord
-import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import java.security.PublicKey
-import javax.management.Query
 
 object MoveToken {
 
     @InitiatingFlow
     @StartableByRPC
-    abstract class Initiator<T: TokenType>(
+    abstract class Initiator<T : TokenType>(
             val token: T,
             val holder: AbstractParty,
             val session: FlowSession? = null
@@ -67,7 +62,7 @@ object MoveToken {
             val sessions = if (ourIdentity == holderParty) emptyList() else listOf(holderSession)
             val finalTx = subFlow(FinalityFlow(transaction = stx, sessions = sessions))
             // If it's TokenPointer, then update the distribution lists for token maintainers
-            if(token is TokenPointer<*>) {
+            if (token is TokenPointer<*>) {
                 subFlow(UpdateDistributionList.Initiator(token, ourIdentity, holderParty))
             }
             return finalTx
@@ -86,22 +81,22 @@ object MoveToken {
     }
 }
 
-class MoveTokenNonFungible<T: TokenType>(
+class MoveTokenNonFungible<T : TokenType>(
         val ownedToken: T,
         holder: AbstractParty,
         session: FlowSession? = null
-): MoveToken.Initiator<T>(ownedToken, holder, session) {
+) : MoveToken.Initiator<T>(ownedToken, holder, session) {
     @Suspendable
     override fun generateMove(): Pair<TransactionBuilder, List<PublicKey>> {
         return generateMoveNonFungible(serviceHub.vaultService, ownedToken, holder)
     }
 }
 
-open class MoveTokenFungible<T: TokenType>(
+open class MoveTokenFungible<T : TokenType>(
         val amount: Amount<T>,
         holder: AbstractParty,
         session: FlowSession? = null
-): MoveToken.Initiator<T>(amount.token, holder, session) {
+) : MoveToken.Initiator<T>(amount.token, holder, session) {
     @Suspendable
     override fun generateMove(): Pair<TransactionBuilder, List<PublicKey>> {
         val tokenSelection = TokenSelection(serviceHub)

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/MoveToken.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/MoveToken.kt
@@ -73,7 +73,7 @@ object MoveToken {
     class Responder(val otherSession: FlowSession) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() {
-            // Resolve the issuance transaction.
+            // Resolve the move transaction.
             if (!serviceHub.myInfo.isLegalIdentity(otherSession.counterparty)) {
                 subFlow(ReceiveFinalityFlow(otherSideSession = otherSession, statesToRecord = StatesToRecord.ONLY_RELEVANT))
             }

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateDistributionList.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateDistributionList.kt
@@ -3,21 +3,16 @@ package com.r3.corda.sdk.token.workflow.flows
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.sdk.token.contracts.states.EvolvableTokenType
 import com.r3.corda.sdk.token.contracts.types.TokenPointer
-import com.r3.corda.sdk.token.workflow.schemas.DistributionRecord
 import com.r3.corda.sdk.token.workflow.utilities.addPartyToDistributionList
-import com.r3.corda.sdk.token.workflow.utilities.getDistributionList
+import com.r3.corda.sdk.token.workflow.utilities.getDistributionRecord
 import net.corda.core.contracts.UniqueIdentifier
-import net.corda.core.crypto.SignedData
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.serialization.serialize
 import net.corda.core.utilities.unwrap
-import java.util.*
-import javax.persistence.criteria.CriteriaQuery
 
 object UpdateDistributionList {
 
@@ -38,13 +33,9 @@ object UpdateDistributionList {
             val distributionListUpdate = DistributionListUpdate(oldParty, newParty, evolvableToken.linearId)
             val maintainers = evolvableToken.maintainers
             val maintainersSessions = maintainers.map { initiateFlow(it) }
-            // Collect signatures from old and new parties
-            val updateBytes = distributionListUpdate.serialize()
-            val ourSig = serviceHub.keyManagementService.sign(updateBytes.bytes, oldParty.owningKey)
-            val signedUpdate = SignedData(updateBytes, ourSig)
             // TODO This is naive quick fix approach for now, we should use data distribution groups
             maintainersSessions.forEach {
-                it.send(signedUpdate)
+                it.send(distributionListUpdate)
             }
         }
     }
@@ -53,40 +44,19 @@ object UpdateDistributionList {
     class Responder(val otherSession: FlowSession) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() {
-            val distListUpdate = otherSession.receive<SignedData<DistributionListUpdate>>().unwrap {
-                val update = it.verified()
-                // Check that request is signed by the oldParty.
-                check(update.oldParty.owningKey == it.sig.by) {
-                    "Got distribution list update request signed by a wrong party."
-                }
+            val distListUpdate = otherSession.receive<DistributionListUpdate>().unwrap {
                 // Check that the request comes from that party.
-                check(update.oldParty == otherSession.counterparty) {
+                check(it.oldParty == otherSession.counterparty) {
                     "Got distribution list update request from a counterparty: ${otherSession.counterparty} " +
-                            "that isn't a signer of request: ${update.oldParty}."
+                            "that isn't a signer of request: ${it.oldParty}."
                 }
-                update
+                it
             }
             // Check that newParty is well known party.
-            serviceHub.identityService.wellKnownPartyFromAnonymous(distListUpdate.newParty)
-                    ?: throw IllegalArgumentException("Don't know about party: ${distListUpdate.newParty}")
-            if (getDistributionRecord(distListUpdate.linearId, distListUpdate.newParty).isEmpty()) {
+            serviceHub.identityService.requireWellKnownPartyFromAnonymous(distListUpdate.newParty)
+            if (getDistributionRecord(serviceHub, distListUpdate.linearId, distListUpdate.newParty).isEmpty()) {
                 // Add new party to the dist list for this token.
                 serviceHub.addPartyToDistributionList(distListUpdate.newParty, distListUpdate.linearId)
-            }
-        }
-
-        @Suspendable
-        private fun getDistributionRecord(linearId: UniqueIdentifier, party: Party): List<DistributionRecord> {
-            return serviceHub.withEntityManager {
-                val query: CriteriaQuery<DistributionRecord> = criteriaBuilder.createQuery(DistributionRecord::class.java)
-                query.apply {
-                    val root = from(DistributionRecord::class.java)
-                    val linearIdEq = criteriaBuilder.equal(root.get<UUID>("linearId"), linearId.id)
-                    val partyEq = criteriaBuilder.equal(root.get<Party>("party"), party)
-                    where(criteriaBuilder.and(linearIdEq, partyEq))
-                    select(root)
-                }
-                createQuery(query).resultList
             }
         }
     }

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateDistributionList.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateDistributionList.kt
@@ -1,0 +1,93 @@
+package com.r3.corda.sdk.token.workflow.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.sdk.token.contracts.states.EvolvableTokenType
+import com.r3.corda.sdk.token.contracts.types.TokenPointer
+import com.r3.corda.sdk.token.workflow.schemas.DistributionRecord
+import com.r3.corda.sdk.token.workflow.utilities.addPartyToDistributionList
+import com.r3.corda.sdk.token.workflow.utilities.getDistributionList
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.crypto.SignedData
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.identity.Party
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.serialize
+import net.corda.core.utilities.unwrap
+import java.util.*
+import javax.persistence.criteria.CriteriaQuery
+
+object UpdateDistributionList {
+
+    @CordaSerializable
+    data class DistributionListUpdate(val oldParty: Party, val newParty: Party, val linearId: UniqueIdentifier)
+
+    // TODO It's ineffective if we are heavily using confidential identities, because we contact maintainers every time we do move
+    // tokens with token pointers.
+    @InitiatingFlow
+    class Initiator<T : EvolvableTokenType>(
+            val tokenPointer: TokenPointer<T>,
+            val oldParty: Party,
+            val newParty: Party
+    ) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val evolvableToken = tokenPointer.pointer.resolve(serviceHub).state.data
+            val distributionListUpdate = DistributionListUpdate(oldParty, newParty, evolvableToken.linearId)
+            val maintainers = evolvableToken.maintainers
+            val maintainersSessions = maintainers.map { initiateFlow(it) }
+            // Collect signatures from old and new parties
+            val updateBytes = distributionListUpdate.serialize()
+            val ourSig = serviceHub.keyManagementService.sign(updateBytes.bytes, oldParty.owningKey)
+            val signedUpdate = SignedData(updateBytes, ourSig)
+            // TODO This is naive quick fix approach for now, we should use data distribution groups
+            maintainersSessions.forEach {
+                it.send(signedUpdate)
+            }
+        }
+    }
+
+    @InitiatedBy(UpdateDistributionList.Initiator::class)
+    class Responder(val otherSession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val distListUpdate = otherSession.receive<SignedData<DistributionListUpdate>>().unwrap {
+                val update = it.verified()
+                // Check that request is signed by the oldParty.
+                check(update.oldParty.owningKey == it.sig.by) {
+                    "Got distribution list update request signed by a wrong party."
+                }
+                // Check that the request comes from that party.
+                check(update.oldParty == otherSession.counterparty) {
+                    "Got distribution list update request from a counterparty: ${otherSession.counterparty} " +
+                            "that isn't a signer of request: ${update.oldParty}."
+                }
+                update
+            }
+            // Check that newParty is well known party.
+            serviceHub.identityService.wellKnownPartyFromAnonymous(distListUpdate.newParty)
+                    ?: throw IllegalArgumentException("Don't know about party: ${distListUpdate.newParty}")
+            if (getDistributionRecord(distListUpdate.linearId, distListUpdate.newParty).isEmpty()) {
+                // Add new party to the dist list for this token.
+                serviceHub.addPartyToDistributionList(distListUpdate.newParty, distListUpdate.linearId)
+            }
+        }
+
+        @Suspendable
+        private fun getDistributionRecord(linearId: UniqueIdentifier, party: Party): List<DistributionRecord> {
+            return serviceHub.withEntityManager {
+                val query: CriteriaQuery<DistributionRecord> = criteriaBuilder.createQuery(DistributionRecord::class.java)
+                query.apply {
+                    val root = from(DistributionRecord::class.java)
+                    val linearIdEq = criteriaBuilder.equal(root.get<UUID>("linearId"), linearId.id)
+                    val partyEq = criteriaBuilder.equal(root.get<Party>("party"), party)
+                    where(criteriaBuilder.and(linearIdEq, partyEq))
+                    select(root)
+                }
+                createQuery(query).resultList
+            }
+        }
+    }
+}

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateEvolvableTokenResponder.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/UpdateEvolvableTokenResponder.kt
@@ -25,6 +25,6 @@ class UpdateEvolvableTokenResponder(val otherSession: FlowSession) : FlowLogic<S
         }
 
         // Resolve the creation transaction.
-        return subFlow(ReceiveFinalityFlow(otherSideSession = otherSession, statesToRecord = StatesToRecord.ONLY_RELEVANT))
+        return subFlow(ReceiveFinalityFlow(otherSideSession = otherSession, statesToRecord = StatesToRecord.ALL_VISIBLE))
     }
 }

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/AddPartyToDistributionList.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/AddPartyToDistributionList.kt
@@ -8,6 +8,7 @@ import net.corda.core.node.ServiceHub
 /**
  * Utility function to persist a new entity pertaining to a distribution record.
  * TODO: Add some error handling.
+ * TODO: Don't duplicate pairs of linearId and party.
  */
 fun ServiceHub.addPartyToDistributionList(party: Party, linearId: UniqueIdentifier) {
     // Create an persist a new entity.

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/QueryUtilities.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/QueryUtilities.kt
@@ -1,5 +1,6 @@
 package com.r3.corda.sdk.token.workflow.utilities
 
+import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.sdk.token.contracts.schemas.PersistentFungibleToken
 import com.r3.corda.sdk.token.contracts.schemas.PersistentNonFungibleToken
 import com.r3.corda.sdk.token.contracts.states.FungibleToken
@@ -38,6 +39,21 @@ fun getDistributionList(services: ServiceHub, linearId: UniqueIdentifier): List<
         query.apply {
             val root = from(DistributionRecord::class.java)
             where(criteriaBuilder.equal(root.get<UUID>("linearId"), linearId.id))
+            select(root)
+        }
+        createQuery(query).resultList
+    }
+}
+
+// Gets the distribution record for a particular token and party.
+fun getDistributionRecord(serviceHub: ServiceHub, linearId: UniqueIdentifier, party: Party): List<DistributionRecord> {
+    return serviceHub.withEntityManager {
+        val query: CriteriaQuery<DistributionRecord> = criteriaBuilder.createQuery(DistributionRecord::class.java)
+        query.apply {
+            val root = from(DistributionRecord::class.java)
+            val linearIdEq = criteriaBuilder.equal(root.get<UUID>("linearId"), linearId.id)
+            val partyEq = criteriaBuilder.equal(root.get<Party>("party"), party)
+            where(criteriaBuilder.and(linearIdEq, partyEq))
             select(root)
         }
         createQuery(query).resultList


### PR DESCRIPTION
Simplified solution for updating the subscription list held by maintainers. There are many problems with this approach and we should move to data distribution lists, but this should do for now.