### PR TITLE
make rowsToAmount in QueryUtilities public to allow for re-use

### DIFF
--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/QueryUtilities.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/QueryUtilities.kt
@@ -119,7 +119,7 @@ fun sumTokenCriteria(): QueryCriteria {
 }
 
 // Abstracts away the nasty 'otherResults' part of the vault query API.
-private fun <T : TokenType> rowsToAmount(token: T, rows: Vault.Page<FungibleToken<T>>): Amount<T> {
+fun <T : TokenType> rowsToAmount(token: T, rows: Vault.Page<FungibleToken<T>>): Amount<T> {
     return if (rows.otherResults.isEmpty()) {
         Amount(0L, token)
     } else {


### PR DESCRIPTION
We'd like to use this function when writing our own `VaultService` extension functions.
Is there anything speaking against making it public?