### PR TITLE
Change AbstractToken<*>.holderString to explicit, dynamic String.

### DIFF
--- a/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/utilities/TokenUtilities.kt
+++ b/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/utilities/TokenUtilities.kt
@@ -59,7 +59,6 @@ internal infix fun <T : EvolvableTokenType> T._withNotary(notary: Party): Transa
  * Converts [holder] into a more friendly string. It uses only the x500 organisation for [Party] objects and
  * shortens the public key for [AnonymousParty]s to the first 16 characters.
  * */
-val AbstractToken<*>.holderString
-    get() = {
+val AbstractToken<*>.holderString: String
+    get() =
         (holder as? Party)?.name?.organisation ?: holder.owningKey.toStringShort().substring(0, 16)
-    }


### PR DESCRIPTION
Fix to TSK-19 **IFF** a bug. 
Changed`TokenUtilities.kt`, to convert `val AbstractToken<*>.holderString` to an explicit `String` and not a `() -> String`, as appears to be expected by all the usages.