### PR TITLE
FungibleTokenContract.verifyMove now allows multiple move commands

### DIFF
--- a/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/FungibleTokenContract.kt
+++ b/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/FungibleTokenContract.kt
@@ -86,7 +86,7 @@ open class FungibleTokenContract<T : TokenType> : AbstractTokenContract<T, Fungi
         }
         val hasZeroAmounts = outputs.any { it.amount == Amount.zero(issuedToken) }
         require(hasZeroAmounts.not()) { "You cannot create output token amounts with a ZERO amount." }
-        // There can be different owners in each move group. There map be one command for each of the signers publickey
+        // There can be different owners in each move group. There may be one command for each of the signers publickey
         // or all the public keys might be listed within one command.
         val inputOwningKeys: Set<PublicKey> = inputs.map { it.holder.owningKey }.toSet()
         val signers: Set<PublicKey> = moveCommands.flatMap(CommandWithParties<TokenCommand<T>>::signers).toSet()

--- a/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/FungibleTokenContract.kt
+++ b/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/FungibleTokenContract.kt
@@ -69,7 +69,8 @@ open class FungibleTokenContract<T : TokenType> : AbstractTokenContract<T, Fungi
             inputs: List<FungibleToken<T>>,
             outputs: List<FungibleToken<T>>
     ) {
-        val issuedToken: IssuedTokenType<T> = moveCommands.single().value.token
+        // Commands are grouped by Token Type, so we just need a token reference.
+        val issuedToken: IssuedTokenType<T> = moveCommands.first().value.token
         // There must be inputs and outputs present.
         require(inputs.isNotEmpty()) { "When moving tokens, there must be input states present." }
         require(outputs.isNotEmpty()) { "When moving tokens, there must be output states present." }

--- a/contract/src/test/kotlin/com/r3/corda/sdk/token/contracts/FungibleTokenTests.kt
+++ b/contract/src/test/kotlin/com/r3/corda/sdk/token/contracts/FungibleTokenTests.kt
@@ -35,6 +35,8 @@ class FungibleTokenTests {
         val ISSUER = TestIdentity(CordaX500Name("ISSUER", "London", "GB"))
         val ALICE = TestIdentity(CordaX500Name("ALICE", "London", "GB"))
         val BOB = TestIdentity(CordaX500Name("BOB", "London", "GB"))
+        val PETER = TestIdentity(CordaX500Name("PETER", "London", "GB"))
+        val PAUL = TestIdentity(CordaX500Name("PAUL", "London", "GB"))
     }
 
     @Rule
@@ -47,6 +49,8 @@ class FungibleTokenTests {
             identityService = mock<IdentityServiceInternal>().also {
                 doReturn(ALICE.party).whenever(it).partyFromKey(ALICE.publicKey)
                 doReturn(BOB.party).whenever(it).partyFromKey(BOB.publicKey)
+                doReturn(PETER.party).whenever(it).partyFromKey(PETER.publicKey)
+                doReturn(PAUL.party).whenever(it).partyFromKey(PAUL.publicKey)
                 doReturn(ISSUER.party).whenever(it).partyFromKey(ISSUER.publicKey)
             },
             networkParameters = testNetworkParameters(
@@ -242,6 +246,16 @@ class FungibleTokenTests {
                 command(ALICE.publicKey, MoveTokenCommand(USD issuedBy BOB.party))
                 // Command for the move.
                 command(ALICE.publicKey, MoveTokenCommand(issuedToken))
+                verifies()
+            }
+
+            // Two moves (one group).
+            tweak {
+                // Add a basic move from Peter to Paul.
+                input(FungibleTokenContract.contractId, 20 of issuedToken heldBy PETER.party)
+                output(FungibleTokenContract.contractId, 20 of issuedToken heldBy PAUL.party)
+                command(ALICE.publicKey, MoveTokenCommand(issuedToken))
+                command(PETER.publicKey, MoveTokenCommand(issuedToken))
                 verifies()
             }
 


### PR DESCRIPTION
Fixes TSK-18 **IFF** it is a bug.
1. Edited `FungibleTokenContract.verifyMove` to retrieve the group Token Type from the `first()` `MoveCommand` instead of the `single()` such command.
2. Attempted a Move Token contract test to confirm results.

**NB** I made this PR because we encountered this problem during testing and it seemed a simple fix. However, my test case **DOES NOT** reproduce the behaviour we encountered exactly and I don't know how to make it do so.  
Our function composes a single transaction from a set of unrelated bilateral move token "sub-transactions". This manifests, at `verifyMove` time, as a `moveCommands` list that has >1 entry.  Thus, the invocation of `single()` was causing contract verification failure.
 