### PR TITLE
Make PartyAndAmount CordaSerializable.

### DIFF
--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/types/PartyAndAmount.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/types/PartyAndAmount.kt
@@ -3,9 +3,11 @@ package com.r3.corda.sdk.token.workflow.types
 import com.r3.corda.sdk.token.contracts.types.TokenType
 import net.corda.core.contracts.Amount
 import net.corda.core.identity.AbstractParty
+import net.corda.core.serialization.CordaSerializable
 
 /**
  * A simple holder for a (possibly anonymous) [AbstractParty] and a quantity of tokens.
  * Used in [generateMove] to define what [amount] of token [T] [party] should receive.
  */
+@CordaSerializable
 data class PartyAndAmount<T : TokenType>(val party: AbstractParty, val amount: Amount<T>)


### PR DESCRIPTION
Made `PartyAndAmount` `CordaSerializable`. 
All it's composed types are already serialisable, so it seemed a basic oversight. Plus we use the class on some Flow APIs and are getting serialization failures across the RPC boundary as a result.. 