### PR TITLE
Fix/smarter asserts

### DIFF
--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/CreateEvolvableTokenTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/CreateEvolvableTokenTests.kt
@@ -40,7 +40,7 @@ class CreateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(maintainerKeys, createTx.requiredSigningKeys, "Must be signed by all maintainers")
 
         // Only Alice should record the transaction
-        assertRecordsTransaction(createTx, alice)
+        assertHasTransaction(createTx, alice)
     }
 
     /**
@@ -62,7 +62,7 @@ class CreateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(maintainerKeys, createTx.requiredSigningKeys, "Must be signed by all maintainers")
 
         // Alice and Bob should record the transaction
-        assertRecordsTransaction(createTx, alice, bob)
+        assertHasTransaction(createTx, alice, bob)
     }
 
     /**
@@ -84,7 +84,7 @@ class CreateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(maintainerKeys, createTx.requiredSigningKeys, "Must be signed by all maintainers")
 
         // Alice and Charlie should record the transaction
-        assertRecordsTransaction(createTx, alice, charlie)
+        assertHasTransaction(createTx, alice, charlie)
     }
 
     /**
@@ -106,7 +106,7 @@ class CreateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(maintainerKeys, createTx.requiredSigningKeys, "Must be signed by all maintainers")
 
         // Alice, Charlie, and Denise should record the transaction
-        assertRecordsTransaction(createTx, alice, charlie, denise)
+        assertHasTransaction(createTx, alice, charlie, denise)
     }
 
     /**
@@ -128,7 +128,7 @@ class CreateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(maintainerKeys, createTx.requiredSigningKeys, "Must be signed by all maintainers")
 
         // Alice, Bob, and Charlie should record the transaction
-        assertRecordsTransaction(createTx, alice, bob, charlie)
+        assertHasTransaction(createTx, alice, bob, charlie)
     }
 
     /**
@@ -150,7 +150,7 @@ class CreateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(maintainerKeys, createTx.requiredSigningKeys, "Must be signed by all maintainers")
 
         // Alice, Bob, Charlie, and Denise should record the transaction
-        assertRecordsTransaction(createTx, alice, bob, charlie, denise)
+        assertHasTransaction(createTx, alice, bob, charlie, denise)
     }
 
     /**

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/DiamondWithTokenScenarioTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/DiamondWithTokenScenarioTests.kt
@@ -105,11 +105,11 @@ class DiamondWithTokenScenarioTests : JITMockNetworkTests() {
      *
      * 1. GIC creates (publishes) 3 diamond grading reports
      */
-    @Test
-    @Ignore
-    fun `create multiple grading reports`() {
-
-    }
+    //    @Test
+    //    @Ignore
+    //    fun `create multiple grading reports`() {
+    //
+    //    }
 
     /**
      * This scenario creates a multiple evolvable token types in a single transaction, and then issues multiple holding
@@ -118,11 +118,11 @@ class DiamondWithTokenScenarioTests : JITMockNetworkTests() {
      * 1. GIC creates (publishes) 3 diamond grading reports
      * 2. Denise (the diamond dealer) issues 2 holdable tokens to self (perhaps as inventory)
      */
-    @Test
-    @Ignore
-    fun `issue multiple grading report tokens`() {
-
-    }
+    //    @Test
+    //    @Ignore
+    //    fun `issue multiple grading report tokens`() {
+    //
+    //    }
 
     /**
      * This scenario creates a new evolvable token type and issues holdable tokens to self.
@@ -130,11 +130,11 @@ class DiamondWithTokenScenarioTests : JITMockNetworkTests() {
      * 1. GIC creates (publishes) the diamond grading report
      * 2. Denise (the diamond dealer) issues a holdable, discrete (non-fungible) token to herself (perhaps as inventory)
      */
-    @Test
-    @Ignore
-    fun `issue a grading report token to self`() {
-
-    }
+    //    @Test
+    //    @Ignore
+    //    fun `issue a grading report token to self`() {
+    //
+    //    }
 
     /**
      * This scenario creates a new evolvable token type, moves it around, and then issues an update. In this case, only
@@ -145,11 +145,11 @@ class DiamondWithTokenScenarioTests : JITMockNetworkTests() {
      * 3. Alice transfers the discrete token to Bob
      * 4. GIC updates (amends) the grading report
      */
-    @Test
-    @Ignore
-    fun `update a grading report and inform token holders`() {
-
-    }
+    //    @Test
+    //    @Ignore
+    //    fun `update a grading report and inform token holders`() {
+    //
+    //    }
 
     /**
      * This scenario tests that the token issuer cannot issue two holdable tokens. In practice, this may be challenging
@@ -159,15 +159,15 @@ class DiamondWithTokenScenarioTests : JITMockNetworkTests() {
      * 2. Denise (the diamond dealer) issues a holdable, discrete (non-fungible) token to Alice
      * 3. Denise then issues a new holdable, discrete (non-fungible) token to Bob
      */
-    @Test
-    @Ignore
-    fun `denise cannot issue multiple ownership tokens`() {
-        // STEP 01: GIC publishes the certificate
-
-        // STEP 02: Denise issues an ownership token
-
-        // STEP 03: Denise issues another ownership token
-    }
+    //    @Test
+    //    @Ignore
+    //    fun `denise cannot issue multiple ownership tokens`() {
+    //        // STEP 01: GIC publishes the certificate
+    //
+    //        // STEP 02: Denise issues an ownership token
+    //
+    //        // STEP 03: Denise issues another ownership token
+    //    }
 
     /**
      * This scenario tests that a token holder should not (really) issue a new holdable token. However, in practice this
@@ -177,16 +177,16 @@ class DiamondWithTokenScenarioTests : JITMockNetworkTests() {
      * 2. Denise (the diamond dealer) issues a holdable, discrete (non-fungible) token to Alice
      * 3. Alice then issues a new holdable, discrete (non-fungible) token to Bob
      */
-    @Test
-    @Ignore
-    fun `alice cannot issue a new ownership token`() {
-        // STEP 01: GIC publishes the certificate
-
-        // STEP 02: Denise issues an ownership token
-
-        // STEP 03: Denise transfers ownership to Alice
-
-        // STEP 04: Alice issues another ownership token
-    }
+    //    @Test
+    //    @Ignore
+    //    fun `alice cannot issue a new ownership token`() {
+    //        // STEP 01: GIC publishes the certificate
+    //
+    //        // STEP 02: Denise issues an ownership token
+    //
+    //        // STEP 03: Denise transfers ownership to Alice
+    //
+    //        // STEP 04: Alice issues another ownership token
+    //    }
 
 }

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/DiamondWithTokenScenarioTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/DiamondWithTokenScenarioTests.kt
@@ -3,14 +3,8 @@ package com.r3.corda.sdk.token.workflow
 import com.r3.corda.sdk.token.contracts.states.NonFungibleToken
 import com.r3.corda.sdk.token.contracts.types.TokenPointer
 import com.r3.corda.sdk.token.workflow.states.DiamondGradingReport
-import net.corda.core.contracts.LinearState
-import net.corda.core.contracts.StateAndRef
-import net.corda.core.node.services.Vault
-import net.corda.core.node.services.queryBy
-import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.node.StartedMockNode
-import org.junit.Ignore
 import org.junit.Test
 import java.time.Duration
 import kotlin.test.assertEquals
@@ -47,7 +41,7 @@ class DiamondWithTokenScenarioTests : JITMockNetworkTests() {
         val publishDiamondTx = gic.createEvolvableToken(diamond, notary.legalIdentity()).getOrThrow()
         val publishedDiamond = publishDiamondTx.singleOutput<DiamondGradingReport>()
         assertEquals(diamond, publishedDiamond.state.data, "Original diamond did not match the published diamond.")
-        denise.watchForTransaction(publishDiamondTx).getOrThrow(Duration.ofSeconds(5))
+        assertHasTransaction(publishDiamondTx, gic, denise)
 
         // STEP 02: Denise creates ownership token
         // Denise issues the token to Alice
@@ -57,36 +51,36 @@ class DiamondWithTokenScenarioTests : JITMockNetworkTests() {
                 issueTo = alice,
                 notary = notary,
                 anonymous = true
-        ).getOrThrow()
+        ).getOrThrow(Duration.ofSeconds(5))
         // GIC should *not* receive a copy of this issuance
-        assertRecordsTransaction(issueTokenTx, alice)
-        assertNotRecordsTransaction(issueTokenTx, gic)
+        assertHasTransaction(issueTokenTx, alice)
+        assertNotHasTransaction(issueTokenTx, gic)
 
         // STEP 03: Alice transfers ownership to Bob
         // Continuing the chain of sale
         val moveTokenToBobTx = alice.moveTokens(diamondPointer, bob, anonymous = true).getOrThrow(Duration.ofSeconds(5))
-        assertRecordsTransaction(moveTokenToBobTx, alice, bob)
-        assertNotRecordsTransaction(moveTokenToBobTx, gic, denise)
+        assertHasTransaction(moveTokenToBobTx, alice, bob)
+        assertNotHasTransaction(moveTokenToBobTx, gic, denise)
 
         // STEP 04: Bob transfers ownership to Charlie
         // Continuing the chain of sale
         val moveTokenToCharlieTx = bob.moveTokens(diamondPointer, charlie, anonymous = true).getOrThrow(Duration.ofSeconds(5))
-        assertRecordsTransaction(moveTokenToCharlieTx, bob, charlie)
-        assertNotRecordsTransaction(moveTokenToCharlieTx, gic, denise, alice)
+        assertHasTransaction(moveTokenToCharlieTx, bob, charlie)
+        assertNotHasTransaction(moveTokenToCharlieTx, gic, denise, alice)
 
         // STEP 05: GIC amends (updates) the grading report
         // This should be reflected to the report participants
         val updatedDiamond = publishedDiamond.state.data.copy(color = DiamondGradingReport.ColorScale.B)
         val updateDiamondTx = gic.updateEvolvableToken(publishedDiamond, updatedDiamond).getOrThrow(Duration.ofSeconds(5))
-        assertRecordsTransaction(updateDiamondTx, gic, denise, bob, charlie)
-        assertNotRecordsTransaction(updateDiamondTx, alice)
+        assertHasTransaction(updateDiamondTx, gic, denise, bob, charlie)
+        assertNotHasTransaction(updateDiamondTx, alice)
 
         // STEP 06: Charlie redeems the token with Denise
         // This should exit the holdable token
         val charlieDiamond = moveTokenToCharlieTx.tx.outputsOfType<NonFungibleToken<TokenPointer<DiamondGradingReport>>>().first()
         val redeemDiamondTx = charlie.redeemTokens(charlieDiamond.token.tokenType, denise).getOrThrow(Duration.ofSeconds(5))
-        assertRecordsTransaction(redeemDiamondTx, charlie, denise)
-        assertNotRecordsTransaction(redeemDiamondTx, gic, alice, bob)
+        assertHasTransaction(redeemDiamondTx, charlie, denise)
+        assertNotHasTransaction(redeemDiamondTx, gic, alice, bob)
 
         // FINAL POSITIONS
 

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/JITMockNetworkTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/JITMockNetworkTests.kt
@@ -2,6 +2,7 @@ package com.r3.corda.sdk.token.workflow
 
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.StartedMockNode
@@ -68,4 +69,13 @@ abstract class JITMockNetworkTests(val names: List<CordaX500Name> = emptyList())
 
     protected val notaryIdentity: Party get() = notary.legalIdentity()
 
+    /**
+     * Smart helper for [assertHasTransaction] that passes in the test suite's network.
+     */
+    protected fun assertHasTransaction(tx: SignedTransaction, vararg nodes: StartedMockNode) = assertHasTransaction(tx, network, *nodes)
+
+    /**
+     * Smart helper for [assertNotHasTransaction] that passes in the test suite's network.
+     */
+    protected fun assertNotHasTransaction(tx: SignedTransaction, vararg nodes: StartedMockNode) = assertNotHasTransaction(tx, network, *nodes)
 }

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TestHelpers.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TestHelpers.kt
@@ -10,11 +10,14 @@ import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.getOrThrow
+import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.StartedMockNode
 import java.time.Duration
 import java.util.concurrent.TimeoutException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 const val DEFAULT_WATCH_FOR_RECORDS_TRANSACTION_TIMEOUT = 10L
 const val DEFAULT_WATCH_FOR_NOT_RECORDS_TRANSACTION_TIMEOUT = 5L
@@ -27,7 +30,12 @@ inline fun <reified T : ContractState> SignedTransaction.singleOutput() = tx.out
 /** Gets the linearId from a LinearState. */
 inline fun <reified T : LinearState> StateAndRef<T>.linearId() = state.data.linearId
 
-/** Check to see if a node recorded a transaction with a particular hash. Return a future signed transaction. */
+/**
+ * Check to see if a node recorded a transaction with a particular hash. Return a future signed transaction.
+ *
+ * *Note*: This method can cause an infinite wait; please see assertHasTransaction for a potentially safer method of
+ * checking that the node has recorded the given transaction.
+ * */
 fun StartedMockNode.watchForTransaction(txId: SecureHash): CordaFuture<SignedTransaction> {
     return transaction { services.validatedTransactions.trackTransaction(txId) }
 }
@@ -36,6 +44,7 @@ fun StartedMockNode.watchForTransaction(tx: SignedTransaction): CordaFuture<Sign
     return watchForTransaction(tx.id)
 }
 
+@Deprecated("Replaced by assertHasTransaction; note that the new method uses SignedTransaction, not SecureHash, and requires the network")
 fun assertRecordsTransaction(txId: SecureHash, vararg nodes: StartedMockNode, timeout: Long = DEFAULT_WATCH_FOR_RECORDS_TRANSACTION_TIMEOUT) {
     nodes.map {
         it.watchForTransaction(txId)
@@ -44,10 +53,12 @@ fun assertRecordsTransaction(txId: SecureHash, vararg nodes: StartedMockNode, ti
     }
 }
 
+@Deprecated("Replaced by assertHasTransaction", ReplaceWith("assertHasTransaction(tx, network, *nodes)"))
 fun assertRecordsTransaction(tx: SignedTransaction, vararg nodes: StartedMockNode, timeout: Long = DEFAULT_WATCH_FOR_RECORDS_TRANSACTION_TIMEOUT) {
     assertRecordsTransaction(tx.id, *nodes, timeout = timeout)
 }
 
+@Deprecated("Replaced by assertNotHasTransaction; note that the new method uses SignedTransaction, not SecureHash, and requires the network")
 fun assertNotRecordsTransaction(txId: SecureHash, vararg nodes: StartedMockNode, timeout: Long = DEFAULT_WATCH_FOR_NOT_RECORDS_TRANSACTION_TIMEOUT) {
     nodes.map {
         it.watchForTransaction(txId)
@@ -56,20 +67,53 @@ fun assertNotRecordsTransaction(txId: SecureHash, vararg nodes: StartedMockNode,
     }
 }
 
+@Deprecated("Replaced by assertNotHasTransaction", ReplaceWith("assertNotHasTransaction(tx, network, *nodes)"))
 fun assertNotRecordsTransaction(tx: SignedTransaction, vararg nodes: StartedMockNode, timeout: Long = DEFAULT_WATCH_FOR_NOT_RECORDS_TRANSACTION_TIMEOUT) {
     assertNotRecordsTransaction(tx.id, *nodes, timeout = timeout)
+}
+
+/**
+ * Check that each node has recorded the provided transaction. Since Corda is asynchronous, we must wait for the network
+ * to stop moving before checking that transactions are recorded.
+ *
+ * See [assertNotHasTransaction] for the negative counterpart to this assert method.
+ *
+ * Unfortunately, there is no way to reach the network from the node; therefore, the network must be provided
+ * explicitly.
+ */
+fun assertHasTransaction(tx: SignedTransaction, network: MockNetwork, vararg nodes: StartedMockNode) {
+    network.waitQuiescent()
+    nodes.forEach {
+        assertNotNull(it.services.validatedTransactions.getTransaction(tx.id), "Could not find ${tx.id} in ${it.legalIdentity()} validated transactions")
+    }
+}
+
+/**
+ * Check that each node has _not_ recorded the provided transaction. Since Corda is asynchronous, we must wait for the
+ * network to stop moving before checking that transactions are not recorded.
+ *
+ * See [assertHasTransaction] for the positive counterpart to this assert method.
+ *
+ * Unfortunately, there is no way to reach the network from the node; therefore, the network must be provided
+ * explicitly.
+ */
+fun assertNotHasTransaction(tx: SignedTransaction, network: MockNetwork, vararg nodes: StartedMockNode) {
+    network.waitQuiescent()
+    nodes.forEach {
+        assertNull(it.services.validatedTransactions.getTransaction(tx.id), "Found ${tx.id} in ${it.legalIdentity()} validated transactions")
+    }
 }
 
 inline fun <reified T : ContractState> assertHasStateAndRef(stateAndRef: StateAndRef<T>, vararg nodes: StartedMockNode, stateStatus: Vault.StateStatus = Vault.StateStatus.UNCONSUMED) {
     val criteria = QueryCriteria.VaultQueryCriteria(stateStatus)
     nodes.forEach {
-        assert(it.services.vaultService.queryBy<T>(criteria).states.contains(stateAndRef)) { "Could not find $stateAndRef in ${it.legalIdentity()} vault." }
+        assert(it.services.vaultService.queryBy<T>(criteria).states.contains(stateAndRef)) { "Could not find $stateAndRef in ${it.legalIdentity()} vault" }
     }
 }
 
 inline fun <reified T : ContractState> assertNotHasStateAndRef(stateAndRef: StateAndRef<T>, vararg nodes: StartedMockNode, stateStatus: Vault.StateStatus = Vault.StateStatus.UNCONSUMED) {
     val criteria = QueryCriteria.VaultQueryCriteria(stateStatus)
     nodes.forEach {
-        assert(!it.services.vaultService.queryBy<T>(criteria).states.contains(stateAndRef)) { "Found $stateAndRef in ${it.legalIdentity()} vault." }
+        assert(!it.services.vaultService.queryBy<T>(criteria).states.contains(stateAndRef)) { "Found $stateAndRef in ${it.legalIdentity()} vault" }
     }
 }

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/UpdateEvolvableTokenTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/UpdateEvolvableTokenTests.kt
@@ -45,7 +45,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.tx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Only Alice should record the transaction
-        assertRecordsTransaction(updateTx, alice)
+        assertHasTransaction(updateTx, alice)
     }
 
     /**
@@ -72,7 +72,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice and Bob should record the transaction
-        assertRecordsTransaction(updateTx, alice, bob)
+        assertHasTransaction(updateTx, alice, bob)
     }
 
     /**
@@ -99,7 +99,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice and Charlie should record the transaction
-        assertRecordsTransaction(updateTx, alice, charlie)
+        assertHasTransaction(updateTx, alice, charlie)
     }
 
     /**
@@ -126,7 +126,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice, Charlie, and Denise should record the transaction
-        assertRecordsTransaction(updateTx, alice, charlie, denise)
+        assertHasTransaction(updateTx, alice, charlie, denise)
     }
 
     /**
@@ -153,7 +153,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice, Bob, and Charlie should record the transaction
-        assertRecordsTransaction(updateTx, alice, bob, charlie)
+        assertHasTransaction(updateTx, alice, bob, charlie)
     }
 
     /**
@@ -180,7 +180,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice, Bob, Charlie, and Denise should record the transaction
-        assertRecordsTransaction(updateTx, alice, bob, charlie, denise)
+        assertHasTransaction(updateTx, alice, bob, charlie, denise)
     }
 
     /**
@@ -226,7 +226,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice, Bob, Charlie, and Denise should record the transaction
-        assertRecordsTransaction(updateTx, alice, bob)
+        assertHasTransaction(updateTx, alice, bob)
     }
 
     /**
@@ -253,7 +253,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice, Bob, Charlie, and Denise should record the transaction
-        assertRecordsTransaction(updateTx, alice, bob)
+        assertHasTransaction(updateTx, alice, bob)
     }
 
     /**
@@ -280,7 +280,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice and Charlie should record the transaction
-        assertRecordsTransaction(updateTx, alice, charlie)
+        assertHasTransaction(updateTx, alice, charlie)
     }
 
     /**
@@ -307,7 +307,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice and Charlie should record the transaction
-        assertRecordsTransaction(updateTx, alice, charlie)
+        assertHasTransaction(updateTx, alice, charlie)
     }
 
     /**
@@ -334,7 +334,7 @@ class UpdateEvolvableTokenTests : JITMockNetworkTests() {
         assertEquals(expectedSigningKeys, updateTx.requiredSigningKeys, "Must be signed by all maintainers and the notary")
 
         // Alice, Bob, Charlie, and Denise should record the transaction
-        assertRecordsTransaction(updateTx, alice, denise)
+        assertHasTransaction(updateTx, alice, denise)
     }
 
 


### PR DESCRIPTION
Attempt to resolve an issue where the CI server sometimes times out during an assertion that a node has or has not recorded a transaction.

This fix implements a guard in front of the assertion that waits for the network to stop moving. Once the network has stopped moving, it implies that all messages have been passed between all participants and that all transactions and states have been recorded.

This relies on `MockNetwork.waitQuiescent()` which, underneath, uses a timed latch currently set to a 30 second timeout.

@roger3cev thanks for the pointers on how to redefine these assertions.

---
_I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org/)._