### PR TITLE
Nimmaj/paging in token selection

### DIFF
--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenSelectionTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenSelectionTests.kt
@@ -92,7 +92,7 @@ class TokenSelectionTests : MockNetworkTest(numberOfNodes = 4) {
         (1..12).map{ I.issueFungibleTokens(A, 1 of CHF).getOrThrow() }
         val tokenSelection = TokenSelection(A.services)
         A.transaction {
-            val tokens = tokenSelection.attemptSpend(12 of CHF, UUID.randomUUID())
+            val tokens = tokenSelection.attemptSpend(12 of CHF, UUID.randomUUID(), pageSize = 5)
             val value = tokens.fold(0L) { acc, token ->
                 acc + token.state.data.amount.quantity
             }

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenSelectionTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenSelectionTests.kt
@@ -1,5 +1,7 @@
 package com.r3.corda.sdk.token.workflow
 
+import com.r3.corda.sdk.token.contracts.utilities.of
+import com.r3.corda.sdk.token.money.CHF
 import com.r3.corda.sdk.token.money.GBP
 import com.r3.corda.sdk.token.money.USD
 import com.r3.corda.sdk.token.workflow.flows.internal.selection.TokenSelection
@@ -8,6 +10,7 @@ import com.r3.corda.sdk.token.workflow.types.PartyAndAmount
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.node.StartedMockNode
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import java.util.*
@@ -82,6 +85,20 @@ class TokenSelectionTests : MockNetworkTest(numberOfNodes = 4) {
         println(transactionBuilder.toWireTransaction(A.services))
         // Just using this to check and see if the output is as expected.
         // TODO: Assert something...
+    }
+
+    @Test
+    fun `should be able to select tokens if you need more than one page to fulfill`() {
+        (1..12).map{ I.issueFungibleTokens(A, 1 of CHF).getOrThrow() }
+        val tokenSelection = TokenSelection(A.services)
+        A.transaction {
+            val tokens = tokenSelection.attemptSpend(12 of CHF, UUID.randomUUID())
+            val value = tokens.fold(0L) { acc, token ->
+                acc + token.state.data.amount.quantity
+            }
+            Assert.assertEquals("should be 12 tokens", 12, tokens.size)
+            Assert.assertEquals("value should be 1200", 1200L, value)
+        }
     }
 
     // TODO: Test with different notaries.


### PR DESCRIPTION
…mbers of states.   test included

Bumped into an issue with the db token selection algorithm where by the token selection blows up with a paging error if there are more than 200 states in the db.

This fix (hopefully!):

 * allows us to select tokens where a single page isn't enough to satisfy the request
 * allows us to select token when the available set of states is more than a single page
 * allows us to specify the page size (in case someone needs control)

TBH the last one was mainly so that we can have a quicker test and not a slow, @ignored test.

Followed the page spec algorithm suggested in the docs site.

Let me know your thoughts!

Thanks :-)