### PR TITLE
Move DummyCommand into internal contracts module

### DIFF
--- a/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/commands/internal/DummyCommand.kt
+++ b/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/commands/internal/DummyCommand.kt
@@ -1,0 +1,7 @@
+package com.r3.corda.sdk.token.contracts.commands.internal
+
+import net.corda.core.contracts.CommandData
+
+// TODO This is a nasty hack because identity sync flow has api takes only transaction, not input state refs in a constructor.
+//   This should be removed after confidential identities refactor.
+class DummyCommand : CommandData

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/issue/ConfidentialIssueTokensFlow.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/issue/ConfidentialIssueTokensFlow.kt
@@ -11,10 +11,12 @@ import net.corda.core.transactions.SignedTransaction
 /**
  * A flow for issuing tokens to confidential keys.
  */
-class ConfidentialIssueTokensFlow<T : TokenType>(
+class ConfidentialIssueTokensFlow<T : TokenType>
+@JvmOverloads
+constructor (
         val tokens: List<AbstractToken<T>>,
         val participantSessions: List<FlowSession>,
-        val observerSessions: List<FlowSession>
+        val observerSessions: List<FlowSession> = emptyList()
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call(): SignedTransaction {

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/issue/IssueTokensFlow.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/issue/IssueTokensFlow.kt
@@ -43,25 +43,29 @@ import net.corda.core.transactions.TransactionBuilder
  * @property participantSessions a list of flow participantSessions for the transaction participants.
  * @property observerSessions a list of flow participantSessions for the transaction observers.
  */
-class IssueTokensFlow<T : TokenType>(
+class IssueTokensFlow<T : TokenType>
+@JvmOverloads
+constructor(
         val tokensToIssue: List<AbstractToken<T>>,
         val participantSessions: List<FlowSession>,
-        val observerSessions: List<FlowSession>
+        val observerSessions: List<FlowSession> = emptyList()
 ) : FlowLogic<SignedTransaction>() {
 
 
     /** Issue a single [FungibleToken]. */
+    @JvmOverloads
     constructor(
             token: FungibleToken<T>,
             participantSessions: List<FlowSession>,
-            observerSessions: List<FlowSession>
+            observerSessions: List<FlowSession> = emptyList()
     ) : this(listOf(token), participantSessions, observerSessions)
 
     /** Issue a single [NonFungibleToken]. */
+    @JvmOverloads
     constructor(
             token: NonFungibleToken<T>,
             participantSessions: List<FlowSession>,
-            observerSessions: List<FlowSession>
+            observerSessions: List<FlowSession> = emptyList()
     ) : this(listOf(token), participantSessions, observerSessions)
 
 //    /* Non-fungible token constructors. */

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/ConfidentialSelectAndMoveFungibleTokensFlow.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/ConfidentialSelectAndMoveFungibleTokensFlow.kt
@@ -11,19 +11,22 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.SignedTransaction
 
-class ConfidentialSelectAndMoveFungibleTokensFlow<T : TokenType>(
+class ConfidentialSelectAndMoveFungibleTokensFlow<T : TokenType>
+@JvmOverloads
+constructor (
         val partiesAndAmounts: List<PartyAndAmount<T>>,
         val participantSessions: List<FlowSession>,
-        val observerSessions: List<FlowSession>,
+        val observerSessions: List<FlowSession> = emptyList(),
         val queryCriteria: QueryCriteria?,
         val changeHolder: AbstractParty? = null
 ) : FlowLogic<SignedTransaction>() {
 
+    @JvmOverloads
     constructor(
             partyAndAmount: PartyAndAmount<T>,
             queryCriteria: QueryCriteria,
             participantSessions: List<FlowSession>,
-            observerSessions: List<FlowSession>,
+            observerSessions: List<FlowSession> = emptyList(),
             changeHolder: AbstractParty?
     ) : this(listOf(partyAndAmount), participantSessions, observerSessions, queryCriteria, changeHolder)
 

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/ConfidentialSelectAndMoveNonFungibleTokensFlow.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/ConfidentialSelectAndMoveNonFungibleTokensFlow.kt
@@ -10,10 +10,12 @@ import net.corda.core.flows.FlowSession
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.SignedTransaction
 
-class ConfidentialSelectAndMoveNonFungibleTokensFlow<T : TokenType>(
+class ConfidentialSelectAndMoveNonFungibleTokensFlow<T : TokenType>
+@JvmOverloads
+constructor (
         val partyAndToken: PartyAndToken<T>,
         val participantSessions: List<FlowSession>,
-        val observerSessions: List<FlowSession>,
+        val observerSessions: List<FlowSession> = emptyList(),
         val queryCriteria: QueryCriteria?
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/MoveTokensFlow.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/MoveTokensFlow.kt
@@ -9,18 +9,20 @@ import net.corda.core.flows.FlowSession
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 
-class MoveTokensFlow<T : TokenType>(
+class MoveTokensFlow<T : TokenType>
+@JvmOverloads
+constructor(
         val inputs: List<StateAndRef<AbstractToken<T>>>,
         val outputs: List<AbstractToken<T>>,
         override val participantSessions: List<FlowSession>,
-        override val observerSessions: List<FlowSession>
+        override val observerSessions: List<FlowSession> = emptyList()
 ) : AbstractMoveTokensFlow() {
-
+    @JvmOverloads
     constructor(
             input: StateAndRef<AbstractToken<T>>,
             output: AbstractToken<T>,
             participantSessions: List<FlowSession>,
-            observerSessions: List<FlowSession>
+            observerSessions: List<FlowSession> = emptyList()
     ) : this(listOf(input), listOf(output), participantSessions, observerSessions)
 
     @Suspendable

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/SelectAndMoveFungibleTokensFlow.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/SelectAndMoveFungibleTokensFlow.kt
@@ -12,19 +12,21 @@ import net.corda.core.transactions.TransactionBuilder
  * Call this for one [TokenType] at a time. If you need to do multiple token types in one transaction then create a new
  * flow, calling [addMoveTokens] for each token type.
  */
-class SelectAndMoveFungibleTokensFlow<T : TokenType>(
+class SelectAndMoveFungibleTokensFlow<T : TokenType>
+@JvmOverloads
+constructor(
         val partiesAndAmounts: List<PartyAndAmount<T>>,
         override val participantSessions: List<FlowSession>,
-        override val observerSessions: List<FlowSession>,
+        override val observerSessions: List<FlowSession> = emptyList(),
         val queryCriteria: QueryCriteria?,
         val changeHolder: AbstractParty? = null
 ) : AbstractMoveTokensFlow() {
-
+    @JvmOverloads
     constructor(
             partyAndAmount: PartyAndAmount<T>,
             queryCriteria: QueryCriteria,
             participantSessions: List<FlowSession>,
-            observerSessions: List<FlowSession>,
+            observerSessions: List<FlowSession> = emptyList(),
             changeHolder: AbstractParty?
     ) : this(listOf(partyAndAmount), participantSessions, observerSessions, queryCriteria, changeHolder)
 

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/SelectAndMoveNonFungibleTokensFlow.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/move/SelectAndMoveNonFungibleTokensFlow.kt
@@ -7,10 +7,12 @@ import net.corda.core.flows.FlowSession
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.TransactionBuilder
 
-class SelectAndMoveNonFungibleTokensFlow<T : TokenType>(
+class SelectAndMoveNonFungibleTokensFlow<T : TokenType>
+@JvmOverloads
+constructor(
         val partyAndToken: PartyAndToken<T>,
         override val participantSessions: List<FlowSession>,
-        override val observerSessions: List<FlowSession>,
+        override val observerSessions: List<FlowSession> = emptyList(),
         val queryCriteria: QueryCriteria?
 ) : AbstractMoveTokensFlow() {
     @Suspendable

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/redeem/RedeemToken.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/redeem/RedeemToken.kt
@@ -1,6 +1,7 @@
 package com.r3.corda.sdk.token.workflow.flows.redeem
 
 import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.sdk.token.contracts.commands.internal.DummyCommand
 import com.r3.corda.sdk.token.contracts.states.AbstractToken
 import com.r3.corda.sdk.token.contracts.states.FungibleToken
 import com.r3.corda.sdk.token.contracts.states.NonFungibleToken
@@ -103,9 +104,6 @@ object RedeemToken {
             return subFlow(ReceiveFinalityFlow(otherSideSession = issuerSession, statesToRecord = StatesToRecord.ONLY_RELEVANT))
         }
     }
-
-    //TODO Another nasty hack because identity sync flow has api that is useless in our case.
-    private class DummyCommand : CommandData
 
     // Called on Issuer side.
     @InitiatedBy(InitiateRedeem::class)

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/shell/IssueTokens.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/shell/IssueTokens.kt
@@ -36,42 +36,44 @@ import net.corda.core.transactions.SignedTransaction
 @StartableByService
 @StartableByRPC
 @InitiatingFlow
-class IssueTokens<T : TokenType>(
+class IssueTokens<T : TokenType>
+@JvmOverloads
+constructor(
         val tokensToIssue: List<AbstractToken<T>>,
-        val observers: List<Party>
+        val observers: List<Party> = emptyList()
 ) : FlowLogic<SignedTransaction>() {
 
     /* Fungible token constructors. */
-
+    @JvmOverloads
     constructor(token: FungibleToken<T>, observers: List<Party> = emptyList())
             : this(listOf(token), observers)
-
+    @JvmOverloads
     constructor(tokenType: T, amount: Long, issuer: Party, holder: Party, observers: List<Party> = emptyList())
             : this(listOf(amount of tokenType issuedBy issuer heldBy holder), observers)
-
+    @JvmOverloads
     constructor(issuedTokenType: IssuedTokenType<T>, amount: Long, holder: AbstractParty, observers: List<Party> = emptyList())
             : this(listOf(amount of issuedTokenType heldBy holder), observers)
-
+    @JvmOverloads
     constructor(issuedTokenType: IssuedTokenType<T>, amount: Long, observers: List<Party> = emptyList())
             : this(listOf(amount of issuedTokenType heldBy issuedTokenType.issuer), observers)
-
+    @JvmOverloads
     constructor(tokenType: T, amount: Long, issuer: Party, observers: List<Party> = emptyList())
             : this(listOf(amount of tokenType issuedBy issuer heldBy issuer), observers)
 
     /* Non-fungible token constructors. */
-
+    @JvmOverloads
     constructor(token: NonFungibleToken<T>, observers: List<Party> = emptyList())
             : this(listOf(token), observers)
-
+    @JvmOverloads
     constructor(tokenType: T, issuer: Party, holder: AbstractParty, observers: List<Party> = emptyList())
             : this(listOf(tokenType issuedBy issuer heldBy holder), observers)
-
+    @JvmOverloads
     constructor(issuedTokenType: IssuedTokenType<T>, holder: AbstractParty, observers: List<Party> = emptyList())
             : this(listOf(issuedTokenType heldBy holder), observers)
-
+    @JvmOverloads
     constructor(issuedTokenType: IssuedTokenType<T>, observers: List<Party> = emptyList())
             : this(listOf(issuedTokenType heldBy issuedTokenType.issuer), observers)
-
+    @JvmOverloads
     constructor(tokenType: T, issuer: Party, observers: List<Party> = emptyList())
             : this(listOf(tokenType issuedBy issuer heldBy issuer), observers)
 

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/shell/MoveTokens.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/shell/MoveTokens.kt
@@ -16,16 +16,18 @@ import net.corda.core.transactions.SignedTransaction
 @StartableByService
 @StartableByRPC
 @InitiatingFlow
-class MoveFungibleTokens<T : TokenType>(
+class MoveFungibleTokens<T : TokenType>
+@JvmOverloads
+constructor(
         val partiesAndAmounts: List<PartyAndAmount<T>>,
-        val observers: List<Party>,
+        val observers: List<Party> = emptyList(),
         val queryCriteria: QueryCriteria? = null,
         val changeHolder: AbstractParty? = null
 ) : FlowLogic<SignedTransaction>() {
-
+    @JvmOverloads
     constructor(
             partyAndAmount: PartyAndAmount<T>,
-            observers: List<Party>,
+            observers: List<Party> = emptyList(),
             queryCriteria: QueryCriteria? = null,
             changeHolder: AbstractParty? = null
     ) : this(listOf(partyAndAmount), observers, queryCriteria, changeHolder)


### PR DESCRIPTION
This is temporary solution, until the API for IdentitySyncFlow changes,
so it doesn't have to take transaction in the constructor.

Add flow overloads for empty observers list.