### PR TITLE
Change softLockType to UNLOCKED_ONLY

### DIFF
--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/internal/selection/TokenSelection.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/internal/selection/TokenSelection.kt
@@ -60,7 +60,8 @@ class TokenSelection(
             additionalCriteria: QueryCriteria,
             sorter: Sort,
             stateAndRefs: MutableList<StateAndRef<FungibleToken<T>>>,
-            pageSize: Int = 200
+            pageSize: Int = 200,
+            softLockingType: QueryCriteria.SoftLockingType = QueryCriteria.SoftLockingType.UNLOCKED_ONLY
     ): Boolean {
         // Didn't need to select any tokens.
         if (requiredAmount.quantity == 0L) {
@@ -71,7 +72,7 @@ class TokenSelection(
         // We only want to return RELEVANT states here.
         val baseCriteria = QueryCriteria.VaultQueryCriteria(
                 contractStateTypes = setOf(FungibleToken::class.java),
-                softLockingCondition = QueryCriteria.SoftLockingCondition(QueryCriteria.SoftLockingType.UNLOCKED_AND_SPECIFIED, listOf(lockId)),
+                softLockingCondition = QueryCriteria.SoftLockingCondition(softLockingType, listOf(lockId)),
                 relevancyStatus = Vault.RelevancyStatus.RELEVANT,
                 status = Vault.StateStatus.UNCONSUMED
         )
@@ -114,6 +115,7 @@ class TokenSelection(
      * Attempt spend of [requiredAmount] of [FungibleToken] T. Returns states that cover given amount. Notice that this function
      * doesn't calculate change. If query criteria is not specified then only owned token amounts are used.
      * Use [QueryUtilities.tokenAmountWithIssuerCriteria] to specify issuer.
+     * Calling attemptSpend multiple time with the same lockId will return next unlocked states.
      *
      * @return List of [FungibleToken]s that satisfy the amount to spend, empty list if none found.
      */

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenSelectionTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenSelectionTests.kt
@@ -53,8 +53,14 @@ class TokenSelectionTests : MockNetworkTest(numberOfNodes = 4) {
         val tokenSelection = TokenSelection(A.services)
         val uuid = UUID.randomUUID()
         val one = A.transaction { tokenSelection.attemptSpend(160.GBP, uuid) }
+        // We need to release the soft lock after acquiring it, this is because we before we used LOCK_AND_SPECIFIED
+        // and now we use UNLOCKED_ONLY. The difference is that LOCK_AND_SPECIFIED lets you re lock tokens you have
+        // already locked, where as with UNLOCKED_ONLY, the tokens which have already been locked are out of scope for
+        // future selections. This _is_ a behavioural change but should only affect unit tests.
+        A.transaction { A.services.vaultService.softLockRelease(uuid) }
         assertEquals(gbpTokens.size, one.size)
         val two = A.transaction { tokenSelection.attemptSpend(175.GBP, uuid) }
+        A.transaction { A.services.vaultService.softLockRelease(uuid) }
         assertEquals(gbpTokens.size, two.size)
         val results = A.transaction { tokenSelection.attemptSpend(25.GBP, uuid) }
         assertEquals(1, results.size)


### PR DESCRIPTION
Multiple calls to addMove in the same flow (with the same lockId) should select next unlocked tokens.