### PR TITLE
Issue 66 fix.

### DIFF
--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/internal/distribution/RequestAdditionToDistributionList.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/internal/distribution/RequestAdditionToDistributionList.kt
@@ -58,7 +58,7 @@ object RequestAdditionToDistributionList {
             val stateAndRef = otherSession.receive<StateAndRef<EvolvableTokenType>>().unwrap { it }
             val linearId = stateAndRef.state.data.linearId
             logger.info("Receiving request from ${otherSession.counterparty} to be added to the distribution list for $linearId.")
-            addPartyToDistributionList(serviceHub, otherSession.counterparty, linearId)
+            addPartyToDistributionList(otherSession.counterparty, linearId)
             otherSession.send(FlowResult.Success)
         }
     }

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/internal/distribution/UpdateDistributionListFlowHandler.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/internal/distribution/UpdateDistributionListFlowHandler.kt
@@ -2,7 +2,6 @@ package com.r3.corda.sdk.token.workflow.flows.internal.distribution
 
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.sdk.token.workflow.utilities.addPartyToDistributionList
-import com.r3.corda.sdk.token.workflow.utilities.getDistributionRecord
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatedBy
@@ -22,9 +21,6 @@ class UpdateDistributionListFlowHandler(val otherSession: FlowSession) : FlowLog
         }
         // Check that receiver is well known party.
         serviceHub.identityService.requireWellKnownPartyFromAnonymous(distListUpdate.receiver)
-        if (getDistributionRecord(serviceHub, distListUpdate.linearId, distListUpdate.receiver).isEmpty()) {
-            // Add new party to the dist list for this token.
-            addPartyToDistributionList(serviceHub, distListUpdate.receiver, distListUpdate.linearId)
-        }
+        addPartyToDistributionList(serviceHub, distListUpdate.receiver, distListUpdate.linearId)
     }
 }

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/internal/distribution/UpdateDistributionListFlowHandler.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/flows/internal/distribution/UpdateDistributionListFlowHandler.kt
@@ -21,6 +21,6 @@ class UpdateDistributionListFlowHandler(val otherSession: FlowSession) : FlowLog
         }
         // Check that receiver is well known party.
         serviceHub.identityService.requireWellKnownPartyFromAnonymous(distListUpdate.receiver)
-        addPartyToDistributionList(serviceHub, distListUpdate.receiver, distListUpdate.linearId)
+        addPartyToDistributionList(distListUpdate.receiver, distListUpdate.linearId)
     }
 }

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/FlowUtilities.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/FlowUtilities.kt
@@ -22,12 +22,12 @@ import java.security.PublicKey
  * TODO: Add some error handling.
  */
 @Suspendable
-fun FlowLogic<*>.addPartyToDistributionList(services: ServiceHub, party: Party, linearId: UniqueIdentifier) {
+fun FlowLogic<*>.addPartyToDistributionList(party: Party, linearId: UniqueIdentifier) {
     // Create an persist a new entity.
-    val hasRecord = hasDistributionRecord(services, linearId, party)
+    val hasRecord = hasDistributionRecord(serviceHub, linearId, party)
     if (!hasRecord) {
         val distributionRecord = DistributionRecord(linearId.id, party)
-        services.withEntityManager { persist(distributionRecord) }
+        serviceHub.withEntityManager { persist(distributionRecord) }
     } else {
         logger.info("Already stored a distribution record for $party and $linearId.")
     }
@@ -83,7 +83,7 @@ fun FlowLogic<*>.addToDistributionList(tokens: List<AbstractToken<TokenPointer<*
         val tokenType = token.tokenType
         val pointer = tokenType.pointer.pointer
         val holder = token.holder.toParty(serviceHub)
-        addPartyToDistributionList(serviceHub, holder, pointer)
+        addPartyToDistributionList(holder, pointer)
     }
 }
 

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/FlowUtilities.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/FlowUtilities.kt
@@ -22,10 +22,16 @@ import java.security.PublicKey
  * TODO: Add some error handling.
  */
 @Suspendable
-fun addPartyToDistributionList(services: ServiceHub, party: Party, linearId: UniqueIdentifier) {
+fun FlowLogic<*>.addPartyToDistributionList(services: ServiceHub, party: Party, linearId: UniqueIdentifier) {
     // Create an persist a new entity.
-    val distributionRecord = DistributionRecord(linearId.id, party)
-    services.withEntityManager { persist(distributionRecord) }
+    val hasRecord = hasDistributionRecord(services, linearId, party)
+    if (!hasRecord) {
+        val distributionRecord = DistributionRecord(linearId.id, party)
+        services.withEntityManager { persist(distributionRecord) }
+    } else {
+        logger.info("Already stored a distribution record for $party and $linearId.")
+    }
+
 }
 
 val LedgerTransaction.participants: List<AbstractParty>
@@ -75,7 +81,9 @@ fun FlowLogic<*>.sessionsForParties(parties: List<AbstractParty>): List<FlowSess
 fun FlowLogic<*>.addToDistributionList(tokens: List<AbstractToken<TokenPointer<*>>>) {
     tokens.forEach { token ->
         val tokenType = token.tokenType
-        addPartyToDistributionList(serviceHub, token.holder.toParty(serviceHub), tokenType.pointer.pointer)
+        val pointer = tokenType.pointer.pointer
+        val holder = token.holder.toParty(serviceHub)
+        addPartyToDistributionList(serviceHub, holder, pointer)
     }
 }
 

--- a/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/QueryUtilities.kt
+++ b/workflow/src/main/kotlin/com/r3/corda/sdk/token/workflow/utilities/QueryUtilities.kt
@@ -45,7 +45,7 @@ fun getDistributionList(services: ServiceHub, linearId: UniqueIdentifier): List<
 }
 
 // Gets the distribution record for a particular token and party.
-fun getDistributionRecord(serviceHub: ServiceHub, linearId: UniqueIdentifier, party: Party): List<DistributionRecord> {
+fun getDistributionRecord(serviceHub: ServiceHub, linearId: UniqueIdentifier, party: Party): DistributionRecord? {
     return serviceHub.withEntityManager {
         val query: CriteriaQuery<DistributionRecord> = criteriaBuilder.createQuery(DistributionRecord::class.java)
         query.apply {
@@ -56,7 +56,11 @@ fun getDistributionRecord(serviceHub: ServiceHub, linearId: UniqueIdentifier, pa
             select(root)
         }
         createQuery(query).resultList
-    }
+    }.singleOrNull()
+}
+
+fun hasDistributionRecord(serviceHub: ServiceHub, linearId: UniqueIdentifier, party: Party): Boolean {
+    return getDistributionRecord(serviceHub, linearId, party) != null
 }
 
 /** Utilities for getting tokens from the vault and performing miscellaneous queries. */

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenFlowTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenFlowTests.kt
@@ -155,7 +155,7 @@ class TokenFlowTests : MockNetworkTest(numberOfNodes = 4) {
         val issueTokenA = I.issueFungibleTokens(A, 50 of housePointer).getOrThrow()
         A.watchForTransaction(issueTokenA.id).toCompletableFuture().getOrThrow()
         // Issue to node B.
-        val issueTokenB = I.issueFungibleTokens(A, 50 of housePointer).getOrThrow()
+        val issueTokenB = I.issueFungibleTokens(B, 50 of housePointer).getOrThrow()
         A.watchForTransaction(issueTokenB.id).toCompletableFuture().getOrThrow()
     }
 
@@ -219,5 +219,20 @@ class TokenFlowTests : MockNetworkTest(numberOfNodes = 4) {
         val confidentialHolder = A.services.keyManagementService.freshKeyAndCert(A.services.myInfo.chooseIdentityAndCert(), false).party.anonymise()
         val moveTokenTx = A.startFlow(MoveFungibleTokens(50.GBP, confidentialHolder)).getOrThrow()
         A.watchForTransaction(moveTokenTx.id).getOrThrow()
+    }
+
+    @Test
+    fun `create evolvable token, then issue to the same node twice, expecting only one distribution record`() {
+        // Create new token.
+        val house = House("24 Leinster Gardens, Bayswater, London", 1_000_000.GBP, listOf(I.legalIdentity()))
+        val housePointer: TokenPointer<House> = house.toPointer()
+        // Create evolvable token on ledger.
+        I.createEvolvableToken(house, NOTARY.legalIdentity()).getOrThrow()
+        // Issue token twice.
+        I.issueFungibleTokens(A, 50 of housePointer).getOrThrow()
+        I.issueFungibleTokens(A, 50 of housePointer).getOrThrow()
+        // Check the distribution list.
+        val distributionList = I.transaction { getDistributionList(I.services, housePointer.pointer.pointer) }
+        assertEquals(distributionList.size, 1)
     }
 }

--- a/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenFlowTests.kt
+++ b/workflow/src/test/kotlin/com/r3/corda/sdk/token/workflow/TokenFlowTests.kt
@@ -156,7 +156,7 @@ class TokenFlowTests : MockNetworkTest(numberOfNodes = 4) {
         A.watchForTransaction(issueTokenA.id).toCompletableFuture().getOrThrow()
         // Issue to node B.
         val issueTokenB = I.issueFungibleTokens(B, 50 of housePointer).getOrThrow()
-        A.watchForTransaction(issueTokenB.id).toCompletableFuture().getOrThrow()
+        B.watchForTransaction(issueTokenB.id).toCompletableFuture().getOrThrow()
     }
 
     @Test


### PR DESCRIPTION
Don't add duplicate records to the distribution list when issuing tokens with evolvable token types.