### PR TITLE
Bypass verify for syncing identities.

### DIFF
--- a/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/commands/internal/DummyCommand.kt
+++ b/contract/src/main/kotlin/com/r3/corda/sdk/token/contracts/commands/internal/DummyCommand.kt
@@ -1,7 +1,0 @@
-package com.r3.corda.sdk.token.contracts.commands.internal
-
-import net.corda.core.contracts.CommandData
-
-// TODO This is a nasty hack because identity sync flow has api takes only transaction, not input state refs in a constructor.
-//   This should be removed after confidential identities refactor.
-class DummyCommand : CommandData


### PR DESCRIPTION
Workaround until we get proper SyncConfidentialIDentitiesFlow API, then
we can get rid of constructing that fake wire transaction only to
extract inputs for confidential identities syncing.