### PR TITLE
Minor Edit: Parallelise the IssueToken and EvolvableToken utility methods

### DIFF
--- a/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/evolvable/CreateEvolvableToken.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/evolvable/CreateEvolvableToken.kt
@@ -24,7 +24,6 @@ class CreateEvolvableToken<T : EvolvableTokenType>(
         val transactionState: TransactionState<T>
 ) : FlowLogic<SignedTransaction>() {
 
-    // TODO Use preferred notary
     constructor(evolvableToken: T, contract: ContractClassName, notary: Party)
             : this(TransactionState(evolvableToken, contract, notary))
 

--- a/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/issue/IssueTokensFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/issue/IssueTokensFlow.kt
@@ -108,7 +108,7 @@ constructor(
         // Initialise the transaction builder with a preferred notary or choose a random notary.
         val transactionBuilder = TransactionBuilder(notary = getPreferredNotary(serviceHub))
         // Add all the specified tokensToIssue to the transaction. The correct commands and signing keys are also added.
-        addIssueTokens(tokensToIssue, transactionBuilder)
+        addIssueTokens(transactionBuilder, tokensToIssue)
         // Create new participantSessions if this is started as a top level flow.
         val signedTransaction = subFlow(ObserverAwareFinalityFlow(transactionBuilder, participantSessions + observerSessions))
         // Update the distribution list.

--- a/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/issue/IssueTokensUtilities.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/issue/IssueTokensUtilities.kt
@@ -17,7 +17,7 @@ import net.corda.core.transactions.TransactionBuilder
 fun addIssueTokens(transactionBuilder: TransactionBuilder, outputs: List<AbstractToken<*>>): TransactionBuilder {
     val outputGroups: Map<IssuedTokenType<TokenType>, List<AbstractToken<*>>> = outputs.groupBy { it.issuedTokenType }
     return transactionBuilder.apply {
-        outputGroups.forEach { issuedTokenType: IssuedTokenType<TokenType>, states: List<AbstractToken<*>> ->
+        outputGroups.forEach { (issuedTokenType: IssuedTokenType<TokenType>, states: List<AbstractToken<*>>) ->
             val issuers = states.map { it.issuer }.toSet()
             require(issuers.size == 1) { "All tokensToIssue must have the same issuer." }
             val issuer = issuers.single()

--- a/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/issue/IssueTokensUtilities.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/issue/IssueTokensUtilities.kt
@@ -14,9 +14,9 @@ import net.corda.core.transactions.TransactionBuilder
  * before this function can be called.
  */
 @Suspendable
-fun addIssueTokens(outputs: List<AbstractToken<*>>, txb: TransactionBuilder): TransactionBuilder {
+fun addIssueTokens(transactionBuilder: TransactionBuilder, outputs: List<AbstractToken<*>>): TransactionBuilder {
     val outputGroups: Map<IssuedTokenType<TokenType>, List<AbstractToken<*>>> = outputs.groupBy { it.issuedTokenType }
-    return txb.apply {
+    return transactionBuilder.apply {
         outputGroups.forEach { issuedTokenType: IssuedTokenType<TokenType>, states: List<AbstractToken<*>> ->
             val issuers = states.map { it.issuer }.toSet()
             require(issuers.size == 1) { "All tokensToIssue must have the same issuer." }
@@ -33,8 +33,8 @@ fun addIssueTokens(outputs: List<AbstractToken<*>>, txb: TransactionBuilder): Tr
  * before this function can be called.
  */
 @Suspendable
-fun addIssueTokens(vararg outputs: AbstractToken<*>, transactionBuilder: TransactionBuilder): TransactionBuilder {
-    return addIssueTokens(outputs.toList(), transactionBuilder)
+fun addIssueTokens(transactionBuilder: TransactionBuilder, vararg outputs: AbstractToken<*>): TransactionBuilder {
+    return addIssueTokens(transactionBuilder, outputs.toList())
 }
 
 /**
@@ -43,6 +43,6 @@ fun addIssueTokens(vararg outputs: AbstractToken<*>, transactionBuilder: Transac
  * called.
  */
 @Suspendable
-fun addIssueTokens(output: AbstractToken<*>, transactionBuilder: TransactionBuilder): TransactionBuilder {
-    return addIssueTokens(listOf(output), transactionBuilder)
+fun addIssueTokens(transactionBuilder: TransactionBuilder, output: AbstractToken<*>): TransactionBuilder {
+    return addIssueTokens(transactionBuilder, listOf(output))
 }

--- a/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/RedeemTokenTest.kt
+++ b/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/RedeemTokenTest.kt
@@ -43,7 +43,7 @@ class RedeemTokenTest : MockNetworkTest(numberOfNodes = 3) {
 
     @Test
     fun `redeem fungible happy path`() {
-        val issueTokenTx = I.issueFungibleTokens(A, 100.GBP).getOrThrow()
+        I.issueFungibleTokens(A, 100.GBP).getOrThrow()
         network.waitQuiescent()
         A.redeemTokens(GBP, I, 100.GBP, true).getOrThrow()
         assertThat(A.services.vaultService.tokenAmountsByToken(GBP).states).isEmpty()
@@ -52,7 +52,7 @@ class RedeemTokenTest : MockNetworkTest(numberOfNodes = 3) {
 
     @Test
     fun `redeem fungible with change`() {
-        val issueTokenTx = I.issueFungibleTokens(A, 100.GBP).getOrThrow()
+        I.issueFungibleTokens(A, 100.GBP).getOrThrow()
         network.waitQuiescent()
         A.redeemTokens(GBP, I, 80.GBP, true).getOrThrow()
         val ownedStates = A.services.vaultService.tokenAmountsByToken(GBP).states
@@ -63,7 +63,7 @@ class RedeemTokenTest : MockNetworkTest(numberOfNodes = 3) {
 
     @Test
     fun `isufficient balance`() {
-        val issueTokenTx = I.issueFungibleTokens(A, 100.GBP).getOrThrow()
+        I.issueFungibleTokens(A, 100.GBP).getOrThrow()
         network.waitQuiescent()
         Assertions.assertThatThrownBy {
             A.redeemTokens(GBP, I, 200.GBP, true).getOrThrow()
@@ -72,9 +72,9 @@ class RedeemTokenTest : MockNetworkTest(numberOfNodes = 3) {
 
     @Test
     fun `different issuers for fungible tokens`() {
-        val issueTokenTx = I.issueFungibleTokens(A, 100.GBP).getOrThrow()
+        I.issueFungibleTokens(A, 100.GBP).getOrThrow()
         network.waitQuiescent()
-        val issueTokenTx2 = B.issueFungibleTokens(A, 100.USD).getOrThrow()
+        B.issueFungibleTokens(A, 100.USD).getOrThrow()
         network.waitQuiescent()
         Assertions.assertThatThrownBy {
             A.redeemTokens(USD, I, 100.USD, true).getOrThrow()
@@ -83,7 +83,7 @@ class RedeemTokenTest : MockNetworkTest(numberOfNodes = 3) {
 
     @Test
     fun `redeem non-fungible happy path`() {
-        val issueTokenTx = I.issueNonFungibleTokens(fooToken, A).getOrThrow()
+        I.issueNonFungibleTokens(fooToken, A).getOrThrow()
         network.waitQuiescent()
         assertThat(A.services.vaultService.ownedTokensByToken(fooToken).states).isNotEmpty()
         A.redeemTokens(fooToken, I, null, true).getOrThrow()
@@ -93,7 +93,7 @@ class RedeemTokenTest : MockNetworkTest(numberOfNodes = 3) {
 
     @Test
     fun `redeem tokens from different issuer - non fungible`() {
-        val issueTokenTx = I.issueNonFungibleTokens(fooToken, A).getOrThrow()
+        I.issueNonFungibleTokens(fooToken, A).getOrThrow()
         network.waitQuiescent()
         assertThat(A.services.vaultService.ownedTokensByToken(fooToken).states).isNotEmpty()
         Assertions.assertThatThrownBy {
@@ -113,7 +113,7 @@ class RedeemTokenTest : MockNetworkTest(numberOfNodes = 3) {
 
     @Test
     fun `redeem states with confidential identities not known to issuer`() {
-        val issueTokenTx = I.issueFungibleTokens(A, 100.GBP).getOrThrow()
+        I.issueFungibleTokens(A, 100.GBP).getOrThrow()
         network.waitQuiescent()
         // Check to see that A was added to I's distribution list.
         val moveTokenTx = A.moveFungibleTokens(50.GBP, B, anonymous = true).getOrThrow()

--- a/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/TokenFlowTests.kt
+++ b/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/TokenFlowTests.kt
@@ -64,7 +64,7 @@ class TokenFlowTests : MockNetworkTest(numberOfNodes = 4) {
 
     @Test
     fun `issue token to yourself`() {
-        val issueTokenTx = I.issueFungibleTokens(I, 100.GBP).getOrThrow()
+        I.issueFungibleTokens(I, 100.GBP).getOrThrow()
         network.waitQuiescent()
         val gbp = I.services.vaultService.tokenBalance(GBP)
         assertEquals(100.GBP, gbp)
@@ -72,7 +72,7 @@ class TokenFlowTests : MockNetworkTest(numberOfNodes = 4) {
 
     @Test
     fun `issue and move fixed tokens`() {
-        val issueTokenTx = I.issueFungibleTokens(A, 100.GBP).getOrThrow()
+        I.issueFungibleTokens(A, 100.GBP).getOrThrow()
         network.waitQuiescent()
         //TODO this test is wrong
         // Check to see that A was added to I's distribution list.
@@ -207,7 +207,7 @@ class TokenFlowTests : MockNetworkTest(numberOfNodes = 4) {
 
     @Test
     fun `move to unknown anonymous party`() {
-        val issueTokenTx = I.issueFungibleTokens(A, 100.GBP).getOrThrow()
+        I.issueFungibleTokens(A, 100.GBP).getOrThrow()
         network.waitQuiescent()
         val confidentialHolder = B.services.keyManagementService.freshKeyAndCert(B.services.myInfo.chooseIdentityAndCert(), false).party.anonymise()
         Assertions.assertThatThrownBy {
@@ -217,10 +217,10 @@ class TokenFlowTests : MockNetworkTest(numberOfNodes = 4) {
 
     @Test
     fun `move to anonymous party on the same node`() {
-        val issueTokenTx = I.issueFungibleTokens(A, 100.GBP).getOrThrow()
+        I.issueFungibleTokens(A, 100.GBP).getOrThrow()
         network.waitQuiescent()
         val confidentialHolder = A.services.keyManagementService.freshKeyAndCert(A.services.myInfo.chooseIdentityAndCert(), false).party.anonymise()
-        val moveTokenTx = A.startFlow(MoveFungibleTokens(50.GBP, confidentialHolder)).getOrThrow()
+        A.startFlow(MoveFungibleTokens(50.GBP, confidentialHolder)).getOrThrow()
         network.waitQuiescent()
     }
 


### PR DESCRIPTION
Make the composable utility methods parallel:

* addIssueToken signature changes
* move EvolvableToken utilities into evolvable module

---
_I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org)._