### PR TITLE
NOTICK: Reenable use of corda-core-deterministic for contracts.

### DIFF
--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'kotlin-jpa'
 apply plugin: 'net.corda.plugins.cordapp'
+
+if (!(corda_release_version in ['4.1'])) {
 apply from: "${rootProject.projectDir}/deterministic.gradle"
+}
 
 sourceSets {
     main {

--- a/deterministic.gradle
+++ b/deterministic.gradle
@@ -1,14 +1,14 @@
-//configurations {
-//    compileClasspath { Configuration c -> deterministic(c) }
-//    //runtimeClasspath { Configuration c -> deterministic(c) }
-//}
-//
-//private final void deterministic(Configuration configuration) {
-//    if (configuration.state == Configuration.State.UNRESOLVED) {
-//        // Ensure that this module uses the deterministic Corda artifacts.
-//        configuration.resolutionStrategy.dependencySubstitution {
-//            substitute module("$corda_release_group:corda-serialization:$corda_release_version") with module("$corda_release_group:corda-serialization-deterministic:$corda_release_version")
-//            substitute module("$corda_release_group:corda-core:$corda_release_version") with module("$corda_release_group:corda-core-deterministic:$corda_release_version")
-//        }
-//    }
-//}
+configurations {
+    compileClasspath { Configuration c -> deterministic(c) }
+    //runtimeClasspath { Configuration c -> deterministic(c) }
+}
+
+private final void deterministic(Configuration configuration) {
+    if (configuration.state == Configuration.State.UNRESOLVED) {
+        // Ensure that this module uses the deterministic Corda artifacts.
+        configuration.resolutionStrategy.dependencySubstitution {
+            substitute module("$corda_release_group:corda-serialization:$corda_release_version") with module("$corda_release_group:corda-serialization-deterministic:$corda_release_version")
+            substitute module("$corda_release_group:corda-core:$corda_release_version") with module("$corda_release_group:corda-core-deterministic:$corda_release_version")
+        }
+    }
+}


### PR DESCRIPTION
If you expect your contracts to work inside the DJVM then you need to be compiling them against `corda-core-determinstic` and not `corda-core`.

_Shooting the messenger fixes **NOTHING!**_

The issue of `net.corda.core.contracts.LinearPointer` not being included in `corda-core-deterministic` was fixed in [#5227](https://github.com/corda/corda/pull/5227), and only involves applying appropriate `@KeepForDJVM` and `@DeleteForDJVM` annotations. The relevant commit should therefore be safe to backport to Corda 4.x branches without breaking any public APIs.