### PR TITLE
NOTICK: Build the money module against corda-core-deterministic too.

### DIFF
--- a/modules/money/build.gradle
+++ b/modules/money/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'net.corda.plugins.cordapp'
 
+if (!(corda_release_version in ['4.1'])) {
+apply from: "${rootProject.projectDir}/deterministic.gradle"
+}
+
 cordapp {
     targetPlatformVersion 4
     minimumPlatformVersion 4


### PR DESCRIPTION
Building a module against `corda-core-deterministic` instead of `corda-core` helps ensure that it will be compatible with the DJVM.