### PR TITLE
small fixes

### DIFF
--- a/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/FungibleTokenContract.kt
+++ b/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/FungibleTokenContract.kt
@@ -52,10 +52,11 @@ open class FungibleTokenContract : AbstractTokenContract<FungibleToken>() {
             // There can only be one issuer per group as the issuer is part of the token which is used to group states.
             // If there are multiple issuers for the same tokens then there will be a group for each issued token. So,
             // the line below should never fail on single().
-            val issuer: Party = this.map { it.state.data }.map(AbstractToken::issuer).toSet().single()
-            // Only the issuer should be signing the issuer command.
-            require(issueCommand.signers.singleOrNull { it == issuer.owningKey } != null) {
-                "The issuer must be the only signing party when an amount of tokens are issued."
+            val issuerKey: PublicKey = this.map { it.state.data }.map(AbstractToken::issuer).toSet().single().owningKey
+            val issueSigners: List<PublicKey> = issueCommand.signers
+            // The issuer should be signing the issue command. Notice that it can be signed by more parties.
+            require(issuerKey in issueSigners) {
+                "The issuer must be the signing party when an amount of tokens are issued."
             }
         }
 

--- a/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/NonFungibleTokenContract.kt
+++ b/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/NonFungibleTokenContract.kt
@@ -5,6 +5,7 @@ import com.r3.corda.lib.tokens.contracts.states.NonFungibleToken
 import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.CommandWithParties
 import net.corda.core.internal.uncheckedCast
+import java.security.PublicKey
 
 /**
  * See kdoc for [FungibleTokenContract].
@@ -26,11 +27,11 @@ class NonFungibleTokenContract : AbstractTokenContract<NonFungibleToken>() {
         require(inputs.isEmpty()) { "When issuing non fungible tokens, there cannot be any input states." }
         require(outputs.size == 1) { "When issuing non fungible tokens, there must be a single output state." }
         val output = outputs.single()
-        // There can only be one issuer per group as the issuer is part of the token which is used to group states.
-        // If there are multiple issuers for the same tokens then there will be a group for each issued token. So,
-        // the line below should never fail on single().
-        require(issueCommand.signers.singleOrNull { it == output.state.data.issuer.owningKey } != null) {
-            "The issuer must be the only signing party when a token is issued."
+        val issuerKey: PublicKey = output.state.data.issuer.owningKey
+        val issueSigners: List<PublicKey> = issueCommand.signers
+        // The issuer should be signing the issue command. Notice that it can be signed by more parties.
+        require(issuerKey in issueSigners) {
+            "The issuer must be the signing party when a token is issued."
         }
     }
 

--- a/contracts/src/test/kotlin/com/r3/corda/lib/tokens/contracts/FungibleTokenTests.kt
+++ b/contracts/src/test/kotlin/com/r3/corda/lib/tokens/contracts/FungibleTokenTests.kt
@@ -33,12 +33,17 @@ class FungibleTokenTests : ContractTestCommon() {
             // Signed by a party other than the issuer.
             tweak {
                 command(BOB.publicKey, IssueTokenCommand(issuedToken, listOf(0)))
-                this `fails with` "The issuer must be the only signing party when an amount of tokens are issued."
+                this `fails with` "The issuer must be the signing party when an amount of tokens are issued."
             }
             // Non issuer signature present.
             tweak {
                 command(listOf(BOB.publicKey, BOB.publicKey), IssueTokenCommand(issuedToken, listOf(0)))
-                this `fails with` "The issuer must be the only signing party when an amount of tokens are issued."
+                this `fails with` "The issuer must be the signing party when an amount of tokens are issued."
+            }
+            // Non issuer signature present.
+            tweak {
+                command(listOf(ISSUER.publicKey, BOB.publicKey), IssueTokenCommand(issuedToken, listOf(0)))
+                verifies()
             }
             // With an incorrect command.
             tweak {

--- a/contracts/src/test/kotlin/com/r3/corda/lib/tokens/contracts/NonFungibleTokenTests.kt
+++ b/contracts/src/test/kotlin/com/r3/corda/lib/tokens/contracts/NonFungibleTokenTests.kt
@@ -30,13 +30,20 @@ class NonFungibleTokenTests : ContractTestCommon() {
             // Signed by a party other than the issuer.
             tweak {
                 command(BOB.publicKey, IssueTokenCommand(issuedToken, outputs = listOf(0)))
-                this `fails with` "The issuer must be the only signing party when a token is issued."
+                this `fails with` "The issuer must be the signing party when a token is issued."
             }
             // Non issuer signature present.
             tweak {
                 command(listOf(BOB.publicKey, BOB.publicKey), IssueTokenCommand(issuedToken, outputs = listOf(0)))
-                this `fails with` "The issuer must be the only signing party when a token is issued."
+                this `fails with` "The issuer must be the signing party when a token is issued."
             }
+
+            // Issuer and other signature present.
+            tweak {
+                command(listOf(ISSUER.publicKey, BOB.publicKey), IssueTokenCommand(issuedToken, outputs = listOf(0)))
+                verifies()
+            }
+
             // With an incorrect command.
             tweak {
                 command(BOB.publicKey, WrongCommand())

--- a/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/redeem/ConfidentialRedeemFungibleTokensFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/redeem/ConfidentialRedeemFungibleTokensFlow.kt
@@ -37,7 +37,7 @@ constructor(
         return subFlow(RedeemFungibleTokensFlow(
                 amount = amount,
                 issuerSession = issuerSession,
-                changeOwner = changeOwner,
+                changeHolder = changeOwner,
                 observerSessions = observerSessions,
                 additionalQueryCriteria = additionalQueryCriteria
         ))

--- a/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/redeem/RedeemFungibleTokensFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/redeem/RedeemFungibleTokensFlow.kt
@@ -10,10 +10,10 @@ import net.corda.core.transactions.TransactionBuilder
 
 /**
  * Inlined flow used to redeem amount of [FungibleToken]s issued by the particular issuer with possible change output
- * paid to the [changeOwner].
+ * paid to the [changeHolder].
  *
  * @param amount amount of token to redeem
- * @param changeOwner owner of possible change output, which defaults to the node identity of the calling node
+ * @param changeHolder owner of possible change output, which defaults to the node identity of the calling node
  * @param issuerSession session with the issuer tokens should be redeemed with
  * @param observerSessions optional sessions with the observer nodes, to witch the transaction will be broadcasted
  * @param additionalQueryCriteria additional criteria for token selection
@@ -23,7 +23,7 @@ class RedeemFungibleTokensFlow
 constructor(
         val amount: Amount<TokenType>,
         override val issuerSession: FlowSession,
-        val changeOwner: AbstractParty? = null,
+        val changeHolder: AbstractParty? = null,
         override val observerSessions: List<FlowSession> = emptyList(),
         val additionalQueryCriteria: QueryCriteria? = null
 ) : AbstractRedeemTokensFlow() {
@@ -34,7 +34,7 @@ constructor(
                 serviceHub = serviceHub,
                 amount = amount,
                 issuer = issuerSession.counterparty,
-                changeOwner = changeOwner ?: ourIdentity,
+                changeOwner = changeHolder ?: ourIdentity,
                 additionalQueryCriteria = additionalQueryCriteria
         )
     }

--- a/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/redeem/RedeemTokensFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/redeem/RedeemTokensFlow.kt
@@ -5,7 +5,6 @@ import com.r3.corda.lib.tokens.contracts.states.AbstractToken
 import com.r3.corda.lib.tokens.contracts.types.TokenType
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatingFlow
 import net.corda.core.transactions.TransactionBuilder
 
 /**
@@ -21,7 +20,6 @@ import net.corda.core.transactions.TransactionBuilder
  * @param observerSessions session with optional observers of the redeem transaction
  */
 // Called on owner side.
-@InitiatingFlow
 class RedeemTokensFlow
 @JvmOverloads
 constructor(

--- a/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/redeem/RedeemTokensFlowHandler.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/redeem/RedeemTokensFlowHandler.kt
@@ -10,7 +10,6 @@ import com.r3.corda.lib.tokens.workflows.internal.flows.finality.TransactionRole
 import net.corda.confidential.IdentitySyncFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.SignTransactionFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.unwrap
@@ -20,7 +19,6 @@ import net.corda.core.utilities.unwrap
  * [RedeemNonFungibleTokensFlow], [RedeemTokensFlow].
  */
 // Called on Issuer side.
-@InitiatedBy(RedeemTokensFlow::class)
 class RedeemTokensFlowHandler(val otherSession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {

--- a/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/rpc/RedeemTokens.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/tokens/workflows/flows/rpc/RedeemTokens.kt
@@ -6,6 +6,7 @@ import com.r3.corda.lib.tokens.workflows.flows.redeem.*
 import com.r3.corda.lib.tokens.workflows.utilities.sessionsForParties
 import net.corda.core.contracts.Amount
 import net.corda.core.flows.*
+import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.SignedTransaction
@@ -19,13 +20,14 @@ constructor(
         val amount: Amount<TokenType>,
         val issuer: Party,
         val observers: List<Party> = emptyList(),
-        val queryCriteria: QueryCriteria? = null
+        val queryCriteria: QueryCriteria? = null,
+        val changeHolder: AbstractParty? = null
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call(): SignedTransaction {
         val observerSessions = sessionsForParties(observers)
         val issuerSession = initiateFlow(issuer)
-        return subFlow(RedeemFungibleTokensFlow(amount, issuerSession, ourIdentity, observerSessions, queryCriteria))
+        return subFlow(RedeemFungibleTokensFlow(amount, issuerSession, changeHolder ?: ourIdentity, observerSessions, queryCriteria))
     }
 }
 


### PR DESCRIPTION
ENT-3942 Loosen restriction that only issuer can be signer on issuance transactions
ENT-3962 Make non-rpc redeem flow not initiating
Add changeHolder to rpc redeem fungible tokens flow