### PR TITLE
NOTICK: Ensure deterministic modules are compiled for Java 8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import static org.gradle.api.JavaVersion.VERSION_1_8
+
 buildscript {
     ext {
         corda_release_group = 'net.corda'
@@ -77,7 +79,7 @@ subprojects {
         kotlinOptions {
             languageVersion = "1.2"
             apiVersion = "1.2"
-            jvmTarget = "1.8"
+            jvmTarget = VERSION_1_8
             javaParameters = true   // Useful for reflection.
         }
     }

--- a/deterministic.gradle
+++ b/deterministic.gradle
@@ -1,3 +1,5 @@
+import static org.gradle.api.JavaVersion.VERSION_1_8
+
 configurations {
     compileClasspath { Configuration c -> deterministic(c) }
     //runtimeClasspath { Configuration c -> deterministic(c) }
@@ -7,8 +9,25 @@ private final void deterministic(Configuration configuration) {
     if (configuration.state == Configuration.State.UNRESOLVED) {
         // Ensure that this module uses the deterministic Corda artifacts.
         configuration.resolutionStrategy.dependencySubstitution {
-            substitute module("$corda_release_group:corda-serialization:$corda_release_version") with module("$corda_release_group:corda-serialization-deterministic:$corda_release_version")
-            substitute module("$corda_release_group:corda-core:$corda_release_version") with module("$corda_release_group:corda-core-deterministic:$corda_release_version")
+            substitute module("$corda_release_group:corda-serialization") with module("$corda_release_group:corda-serialization-deterministic:$corda_release_version")
+            substitute module("$corda_release_group:corda-core") with module("$corda_release_group:corda-core-deterministic:$corda_release_version")
+        }
+    }
+}
+
+tasks.withType(JavaCompile) {
+    // The DJVM only supports byte-code up to Java 8.
+    sourceCompatibility = VERSION_1_8
+    targetCompatibility = VERSION_1_8
+}
+
+tasks.withType(AbstractCompile) {
+    // This is a bit ugly, but Gradle isn't recognising the KotlinCompile task
+    // as it does the built-in JavaCompile task.
+    if (it.class.name.startsWith('org.jetbrains.kotlin.gradle.tasks.KotlinCompile')) {
+        kotlinOptions {
+            // The DJVM only supports byte-code up to Java 8.
+            jvmTarget = VERSION_1_8
         }
     }
 }


### PR DESCRIPTION
Small Gradle enhancement to ensure deterministic modules are still compiled for Java 8, even if/when you eventually port to Java 11.

Note that Kotlin 1.2.x can _only_ be compiled to either Java 6 or Java 8 byte-code. Compiling for Java 9+ requires Kotlin >= 1.3.30.