### PR TITLE
NOTICK: Make it easier for Java developers to build Tokens correctly.

### DIFF
--- a/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/states/FungibleToken.kt
+++ b/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/states/FungibleToken.kt
@@ -35,7 +35,7 @@ import net.corda.core.schemas.QueryableState
  * @property holder the [AbstractParty] which has a claim on the issuer of the [IssuedTokenType].
  */
 @BelongsToContract(FungibleTokenContract::class)
-open class FungibleToken(
+open class FungibleToken @JvmOverloads constructor(
         override val amount: Amount<IssuedTokenType>,
         override val holder: AbstractParty,
         override val tokenTypeJarHash: SecureHash? = amount.token.tokenType.getAttachmentIdForGenericParam()

--- a/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/states/NonFungibleToken.kt
+++ b/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/states/NonFungibleToken.kt
@@ -37,7 +37,7 @@ import net.corda.core.schemas.QueryableState
  * @param TokenType the [TokenType].
  */
 @BelongsToContract(NonFungibleTokenContract::class)
-open class NonFungibleToken(
+open class NonFungibleToken @JvmOverloads constructor(
         val token: IssuedTokenType,
         override val holder: AbstractParty,
         override val linearId: UniqueIdentifier,

--- a/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/utilities/AmountUtilities.kt
+++ b/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/utilities/AmountUtilities.kt
@@ -1,3 +1,4 @@
+@file:JvmName("AmountUtilities")
 package com.r3.corda.lib.tokens.contracts.utilities
 
 import com.r3.corda.lib.tokens.contracts.types.IssuedTokenType

--- a/contracts/src/test/java/com/r3/corda/lib/tokens/contracts/FungibleTokenJavaTests.java
+++ b/contracts/src/test/java/com/r3/corda/lib/tokens/contracts/FungibleTokenJavaTests.java
@@ -1,0 +1,16 @@
+package com.r3.corda.lib.tokens.contracts;
+
+import com.r3.corda.lib.tokens.contracts.states.FungibleToken;
+import com.r3.corda.lib.tokens.contracts.types.IssuedTokenType;
+import org.junit.Test;
+
+import static com.r3.corda.lib.tokens.contracts.utilities.AmountUtilities.amount;
+import static com.r3.corda.lib.tokens.testing.states.Rubles.RUB;
+
+public class FungibleTokenJavaTests extends ContractTestCommon {
+    @Test
+    public void testFungibleToken() {
+        IssuedTokenType issuedRubles = new IssuedTokenType(ALICE.getParty(), RUB);
+        new FungibleToken(amount(10, issuedRubles), ALICE.getParty());
+    }
+}

--- a/contracts/src/test/java/com/r3/corda/lib/tokens/contracts/NonFungibleTokenJavaTests.java
+++ b/contracts/src/test/java/com/r3/corda/lib/tokens/contracts/NonFungibleTokenJavaTests.java
@@ -1,0 +1,16 @@
+package com.r3.corda.lib.tokens.contracts;
+
+import com.r3.corda.lib.tokens.contracts.states.NonFungibleToken;
+import com.r3.corda.lib.tokens.contracts.types.IssuedTokenType;
+import net.corda.core.contracts.UniqueIdentifier;
+import org.junit.Test;
+
+import static com.r3.corda.lib.tokens.testing.states.Rubles.RUB;
+
+public class NonFungibleTokenJavaTests extends ContractTestCommon {
+    @Test
+    public void testFungibleToken() {
+        IssuedTokenType issuedRubles = new IssuedTokenType(ALICE.getParty(), RUB);
+        new NonFungibleToken(issuedRubles, ALICE.getParty(), new UniqueIdentifier());
+    }
+}

--- a/contracts/src/test/kotlin/com/r3/corda/lib/tokens/contracts/ContractTestCommon.kt
+++ b/contracts/src/test/kotlin/com/r3/corda/lib/tokens/contracts/ContractTestCommon.kt
@@ -31,11 +31,17 @@ import org.junit.Rule
 abstract class ContractTestCommon {
 
     protected companion object {
+        @JvmField
         val NOTARY = TestIdentity(DUMMY_NOTARY_NAME, 20)
+        @JvmField
         val ISSUER = TestIdentity(CordaX500Name("ISSUER", "London", "GB"))
+        @JvmField
         val ALICE = TestIdentity(CordaX500Name("ALICE", "London", "GB"))
+        @JvmField
         val BOB = TestIdentity(CordaX500Name("BOB", "London", "GB"))
+        @JvmField
         val CHARLIE = TestIdentity(CordaX500Name("CHARLIE", "London", "GB"))
+        @JvmField
         val DAENERYS = TestIdentity(CordaX500Name("DAENERYS", "London", "GB"))
     }
 

--- a/modules/contracts-for-testing/src/main/kotlin/com/r3/corda/lib/tokens/testing/states/Rubles.kt
+++ b/modules/contracts-for-testing/src/main/kotlin/com/r3/corda/lib/tokens/testing/states/Rubles.kt
@@ -1,3 +1,4 @@
+@file:JvmName("Rubles")
 package com.r3.corda.lib.tokens.testing.states
 
 import com.r3.corda.lib.tokens.contracts.FungibleTokenContract
@@ -30,7 +31,9 @@ class PhoBowl : TokenType("PTK", 0) {
 
 }
 
+@JvmField
 val RUB = Ruble()
+@JvmField
 val PTK = PhoBowl()
 
 data class Appartment(val id: String = "Foo") : TokenType(id, 0)


### PR DESCRIPTION
A `Token` _must_ know which attachment defines its `TokenType`. Kotlin developers have a default constructor parameter to help them, but Java developers need to call the appropriate Magic Function themselves. Help Java developers out by creating suitable secondary constructors.