### PR TITLE
Make holder column of (non)-fungible-token tables nullable

### DIFF
--- a/workflows/src/main/resources/migration/fungible-token-schema.changelog-1.xml
+++ b/workflows/src/main/resources/migration/fungible-token-schema.changelog-1.xml
@@ -20,4 +20,8 @@
         <customChange class="com.r3.corda.lib.tokens.workflows.OwnerMigration"/>
     </changeSet>
 
+    <changeSet author="R3.Corda" id="make_holder_column_nullable">
+        <dropNotNullConstraint tableName="fungible_token" columnName="holder" columnDataType="NVARCHAR(255)"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/workflows/src/main/resources/migration/non-fungible-token-schema.changelog-1.xml
+++ b/workflows/src/main/resources/migration/non-fungible-token-schema.changelog-1.xml
@@ -3,6 +3,8 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
-    <include file="migration/non-fungible-token-schema.changelog-init.xml"/>
-    <include file="migration/non-fungible-token-schema.changelog-1.xml"/>
+    <changeSet author="R3.Corda" id="make_holder_column_nullable">
+        <dropNotNullConstraint tableName="non_fungible_token" columnName="holder" columnDataType="NVARCHAR(255)"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
When using Confidential Identities in a setup where TXs are sent to an observer node, the observer node cannot resolve the AnonymousParty (resulting from Confidential Identities) into an actual Party. As such when storing Tokens that result from above TXs we see this error message:

```
|19:12:45,543|W|Node thread-5            | 3226|X500NameAsStringConverter|Identity service unable to resolve AbstractParty: Anonymous(DL3VRu4wU4GLpF9jpKhZk3GjjUUKTcGekbnkvCMRNT2pk8)|{fiber-id=10000314, flow-id=ad969caa-ede1-4fee-b90b-905a20dff485, flow-logic=com.sdx.observer.workflows.ReportTransactionResponderFlow, flow-logic-simple=ReportTransactionResponderFlow, invocation_id=a9d9ea04-07a2-4987-95dc-b0346fa2e6c1, invocation_timestamp=2020-12-08T18:12:45.215Z, origin=O=Q9IlF5pTCT, L=Zurich, C=CH, session_id=a9d9ea04-07a2-4987-95dc-b0346fa2e6c1, session_timestamp=2020-12-08T18:12:45.215Z, thread-id=3226, tx_id=E193CA840175CE5E2D695E14F07280723537FEB6BE8307E0648A1BA1DFEB2C47}|

|19:12:45,544|E|Node thread-5            | 3226|bc.spi.SqlExceptionHelper|NULL not allowed for column "HOLDER"; SQL statement:
```
This MR will resolve those issues as it will allow us to update the database queryable state table even when the value for holder is NULL.