### PR TITLE
Fixed error extending FungibleToken in Java

### DIFF
--- a/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/states/FungibleToken.kt
+++ b/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/states/FungibleToken.kt
@@ -63,7 +63,7 @@ open class FungibleToken @JvmOverloads constructor(
         else -> throw IllegalArgumentException("Unrecognised schema $schema")
     }
 
-    override fun supportedSchemas() = listOf(FungibleTokenSchemaV1)
+    override fun supportedSchemas() : Iterable<MappedSchema> = listOf(FungibleTokenSchemaV1)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true


### PR DESCRIPTION
Fixed compilation error in Java "return type List<FungibleTokenSchemaV1> is not compatible with Iterable<MappedSchema>" when trying to extend a fungible token