### PR TITLE
CORDA-4169: Update to Corda 4.5.1, Corda Gradle plugins 5.0.14, Gradle 5.6.4.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,10 @@ import static org.gradle.api.JavaVersion.VERSION_1_8
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.3'
+        corda_release_version = '4.5.1'
         tokens_release_group = "com.r3.corda.lib.tokens"
-        tokens_release_version = "1.2-SNAPSHOT"
-        corda_gradle_plugins_version = '5.0.8'
-        kotlin_version = '1.2.71'
-        junit_version = '4.12'
-        dokka_version = '0.9.17'
+        tokens_release_version = "1.2.4-SNAPSHOT"
+        junit_version = '4.13.2'
         slf4j_version = '1.7.25'
         log4j_version = '2.9.1'
         jackson_version = '2.9.0'
@@ -19,32 +16,16 @@ buildscript {
         mavenVersion = '3.1.0'
         maven_resolver_version = "1.1.1"
     }
-
-    repositories {
-        jcenter()
-        mavenCentral()
-        mavenLocal()
-        maven { url "http://ci-artifactory.corda.r3cev.com/artifactory/corda-releases" }
-        maven { url "https://repo.gradle.org/gradle/libs-releases-local/" }
-    }
-
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.kotlin:kotlin-noarg:$kotlin_version"
-        classpath "net.corda.plugins:cordformation:$corda_gradle_plugins_version"
-        classpath "net.corda.plugins:quasar-utils:$corda_gradle_plugins_version"
-        classpath "net.corda.plugins:cordapp:$corda_gradle_plugins_version"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
-    }
 }
 
 plugins {
-    id "com.jfrog.artifactory" version "4.7.5"
+    id "org.jetbrains.kotlin.jvm" apply false
+    id 'com.jfrog.artifactory'
 }
 
 allprojects {
-    version "$tokens_release_version"
-    group "$tokens_release_group"
+    version tokens_release_version
+    group tokens_release_group
 
     configurations.all {
         resolutionStrategy {
@@ -62,21 +43,30 @@ allprojects {
 
 subprojects {
     repositories {
-        jcenter()
         mavenCentral()
         mavenLocal()
-        maven { url 'https://jitpack.io' }
-        maven { url "http://ci-artifactory.corda.r3cev.com/artifactory/corda-dev" }
-        maven { url "http://ci-artifactory.corda.r3cev.com/artifactory/corda-releases" }
-        maven { url "http://ci-artifactory.corda.r3cev.com/artifactory/corda-lib" }
-        maven { url "http://ci-artifactory.corda.r3cev.com/artifactory/corda-lib-dev" }
-        maven { url "http://ci-artifactory.corda.r3cev.com/artifactory/corda-lib" }
+        jcenter {
+            content {
+                includeGroup 'com.beust'
+            }
+        }
+        maven { url "$artifactory_contextUrl/corda-releases" }
+        maven { url "$artifactory_contextUrl/corda-dependencies" }
+        maven { url "$artifactory_contextUrl/corda-lib" }
         maven { url "https://repo.gradle.org/gradle/libs-releases-local/" }
     }
 
-    apply plugin: 'kotlin'
+    pluginManager.withPlugin('org.jetbrains.kotlin.plugin.allopen') {
+        allOpen {
+            annotations(
+                'javax.persistence.Entity',
+                'javax.persistence.Embeddable',
+                'javax.persistence.MappedSuperclass'
+            )
+        }
+    }
 
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
             languageVersion = "1.2"
             apiVersion = "1.2"
@@ -85,15 +75,18 @@ subprojects {
         }
     }
 
-    tasks.withType(Jar) {
-        jar {
-            exclude "**/log4j2*.xml"
-        }
+    tasks.withType(Jar).configureEach {
+        exclude "**/log4j2*.xml"
     }
 
-    tasks.withType(Test){
+    tasks.withType(Test).configureEach {
         minHeapSize = "128m"
         maxHeapSize = "4096m"
+
+        doFirst {
+            // Prevent the project from creating temporary files outside of the build directory.
+            systemProperty 'java.io.tmpdir', buildDir.absolutePath
+        }
     }
 }
 
@@ -107,27 +100,30 @@ configure(publishProjects) { subproject ->
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.artifactory'
 
-    task sourceJar(type: Jar, dependsOn: subproject.classes) {
-        classifier = 'sources'
-        from sourceSets.main.allSource
+    tasks.register('install') {
+        dependsOn 'publishToMavenLocal'
     }
-
-    task javadocJar(type: Jar, dependsOn: subproject.javadoc) {
-        classifier = 'javadoc'
-        from javadoc.destinationDir
-    }
-
-    task install(dependsOn: 'publishToMavenLocal')
 
     publishing {
         publications {
             create(subproject.name, MavenPublication) {
-                from components.java
+                pluginManager.withPlugin('java') {
+                    from components.java
+
+                    artifact tasks.create('sourceJar', Jar) {
+                        dependsOn subproject.classes
+                        archiveClassifier = 'sources'
+                        from sourceSets.main.allSource
+                    }
+                    artifact tasks.create('javadocJar', Jar) {
+                        dependsOn subproject.javadoc
+                        archiveClassifier = 'javadoc'
+                        from javadoc.destinationDir
+                    }
+                }
 
                 groupId subproject.group
                 artifactId "tokens-${subproject.name}"
-                artifact tasks.sourceJar
-                artifact tasks.javadocJar
 
                 pom {
                     description = subproject.description
@@ -140,7 +136,7 @@ configure(publishProjects) { subproject ->
 
 artifactory {
     publish {
-        contextUrl = 'https://ci-artifactory.corda.r3cev.com/artifactory'
+        contextUrl = artifactory_contextUrl
         repository {
             repoKey = 'corda-lib-dev'
             username = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: System.getProperty('corda.artifactory.username')
@@ -156,8 +152,8 @@ artifactory {
 }
 
 wrapper {
-    gradleVersion = "5.6"
-    distributionType = Wrapper.DistributionType.ALL
+    gradleVersion = "5.6.4"
+    distributionType = Wrapper.DistributionType.BIN
 }
 
 //add for test re-run

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -1,5 +1,9 @@
-apply plugin: 'kotlin-jpa'
-apply plugin: 'net.corda.plugins.cordapp'
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.kotlin.plugin.jpa'
+    id 'org.jetbrains.kotlin.plugin.allopen'
+    id 'net.corda.plugins.cordapp'
+}
 
 if (!(corda_release_version in ['4.1'])) {
     apply from: "${rootProject.projectDir}/deterministic.gradle"
@@ -23,9 +27,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Corda dependencies.
-    cordaCompile("$corda_release_group:corda-core:$corda_release_version") {
-        changing = true
-    }
+    cordaCompile "$corda_release_group:corda-core:$corda_release_version"
 
     // Logging.
     testCompile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
@@ -52,5 +54,5 @@ cordapp {
 }
 
 jar {
-    baseName "tokens-contracts"
+    archiveBaseName = "tokens-contracts"
 }

--- a/contracts/src/test/kotlin/com/r3/corda/lib/tokens/contracts/ContractTestCommon.kt
+++ b/contracts/src/test/kotlin/com/r3/corda/lib/tokens/contracts/ContractTestCommon.kt
@@ -50,7 +50,7 @@ abstract class ContractTestCommon {
     val testSerialization = SerializationEnvironmentRule()
 
     protected val aliceServices = MockServices(
-            cordappPackages = listOf("com.r3.corda.lib.tokens.contracts", "com.r3.corda.lib.tokens.money"),
+            cordappPackages = listOf("com.r3.corda.lib.tokens.contracts"),
             initialIdentity = ALICE,
             identityService = mock<IdentityService>().also {
                 doReturn(ALICE.party).whenever(it).partyFromKey(ALICE.publicKey)

--- a/freighter-tests/build.gradle
+++ b/freighter-tests/build.gradle
@@ -1,11 +1,12 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
-apply plugin: 'kotlin'
-apply plugin: 'idea'
-
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'idea'
+}
 
 repositories {
-    maven { url "http://ci-artifactory.corda.r3cev.com/artifactory/freighter-dev" }
+    maven { url "$artifactory_contextUrl/freighter-dev" }
 }
 
 sourceSets {
@@ -18,10 +19,8 @@ sourceSets {
     }
 }
 
-evaluationDependsOn(":workflows")
-task freighterTest(type: Test, dependsOn: [project(":workflows").jar]) {
+tasks.register('freighterTest', Test) {
     maxParallelForks 2
-    systemProperty "java.util.concurrent.ForkJoinPool.common.parallelism", "128"
     testClassesDirs = sourceSets.freighterTest.output.classesDirs
     classpath = sourceSets.freighterTest.runtimeClasspath
     useJUnitPlatform {
@@ -36,29 +35,35 @@ task freighterTest(type: Test, dependsOn: [project(":workflows").jar]) {
             excludeTags "FULL_LINUX_KERNEL"
         }
     }
+
+    doFirst {
+        systemProperty "java.util.concurrent.ForkJoinPool.common.parallelism", "128"
+        systemProperty 'test.corda.release.version', corda_release_version
+    }
 }
 
 configurations {
-    freighterTestCompile.extendsFrom testCompile
-    freighterTestRuntime.extendsFrom testRuntime
+    freighterTestCompile {
+        canBeConsumed = false
+        canBeResolved = false
+        extendsFrom testCompile
+    }
+    freighterTestRuntime {
+        canBeConsumed = false
+        canBeResolved = false
+        extendsFrom testRuntime
+    }
+    freighterTestCompileClasspath {
+        attributes { attr ->
+            attr.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+        }
+    }
 }
 
 dependencies {
     freighterTestCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    freighterTestCompile "freighter:freighter-testing-core-junit5:0.4.5-SNAPSHOT"
+    freighterTestCompile "freighter:freighter-testing-core-junit5:$freighter_version"
 
     freighterTestCompile project(":contracts")
     freighterTestCompile project(":workflows")
 }
-
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions {
-        languageVersion = "1.2"
-        apiVersion = "1.2"
-        jvmTarget = "1.8"
-        javaParameters = true   // Useful for reflection.
-    }
-}
-
-

--- a/freighter-tests/src/freighterTest/kotlin/freighter/testing/TokenSDKDBCompatibility.kt
+++ b/freighter-tests/src/freighterTest/kotlin/freighter/testing/TokenSDKDBCompatibility.kt
@@ -3,35 +3,24 @@ package freighter.testing
 import com.r3.corda.lib.tokens.contracts.states.FungibleToken
 import com.r3.corda.lib.tokens.contracts.types.IssuedTokenType
 import com.r3.corda.lib.tokens.contracts.types.TokenType
-import com.r3.corda.lib.tokens.workflows.OwnerMigration
 import com.r3.corda.lib.tokens.workflows.flows.rpc.IssueTokens
 import freighter.deployments.DeploymentContext
 import freighter.deployments.NodeBuilder
 import freighter.deployments.SingleNodeDeployment
+import freighter.deployments.UnitOfDeployment.DeploymentVersion
 import freighter.machine.DeploymentMachineProvider
 import freighter.machine.generateRandomString
-import liquibase.database.DatabaseConnection
-import liquibase.database.core.PostgresDatabase
 import net.corda.core.contracts.Amount
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
-import net.corda.nodeapi.internal.persistence.DatabaseConfig
-import org.hamcrest.MatcherAssert
-import org.hamcrest.core.Is
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import utility.LoggingUtils
-import utility.Retry
-import utility.getArtifactAndDependencies
+import org.junit.jupiter.api.fail
 import utility.getOrThrow
-import java.net.URLClassLoader
-import java.sql.Connection
-import java.sql.Driver
 import java.time.Duration
-import java.util.*
-import java.util.concurrent.CompletableFuture
 
 class TokenSDKDBCompatibility : DockerRemoteMachineBasedTest() {
+    private val testCordaReleaseVersion: String = System.getProperty("test.corda.release.version")
+        ?: fail("test.corda.release.version system property missing.")
 
     val tokenContracts =
             NodeBuilder.DeployedCordapp.fromClassPath("tokens-contracts")
@@ -90,7 +79,7 @@ class TokenSDKDBCompatibility : DockerRemoteMachineBasedTest() {
                         .withCordapp(tokenSelection)
                         .withCordapp(modernCiV1)
                         .withDatabase(machineProvider.requestDatabase(db))
-        ).withVersion("4.3")
+        ).withVersion(DeploymentVersion(testCordaReleaseVersion, false))
                 .deploy(deploymentContext)
 
         val nodeMachine = deploymentResult.getOrThrow().nodeMachines.single()
@@ -110,6 +99,4 @@ class TokenSDKDBCompatibility : DockerRemoteMachineBasedTest() {
         }
         println("Successfully issued tokens: ${issueTx.coreTransaction.outputs}")
     }
-
 }
-

--- a/freighter-tests/src/freighterTest/kotlin/freighter/testing/TokenSDKUpgradeDBCompatibility.kt
+++ b/freighter-tests/src/freighterTest/kotlin/freighter/testing/TokenSDKUpgradeDBCompatibility.kt
@@ -10,6 +10,7 @@ import com.stress.flows.CreateNewCIFlow
 import freighter.deployments.DeploymentContext
 import freighter.deployments.NodeBuilder
 import freighter.deployments.SingleNodeDeployment
+import freighter.deployments.UnitOfDeployment.DeploymentVersion
 import freighter.machine.DeploymentMachineProvider
 import freighter.machine.generateRandomString
 import net.corda.core.contracts.Amount
@@ -18,13 +19,14 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers.*
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
 import utility.getOrThrow
 import java.time.Duration
-import java.util.concurrent.CompletableFuture
 
 class TokenSDKUpgradeDBCompatibility : DockerRemoteMachineBasedTest() {
+	private val testCordaReleaseVersion: String = System.getProperty("test.corda.release.version")
+		?: fail("test.corda.release.version system property missing.")
 
 	//remove the prod key and sign with freighter key
 	val tokensV1Contracts = NodeBuilder.DeployedCordapp.fromGradleArtifact(
@@ -100,7 +102,7 @@ class TokenSDKUpgradeDBCompatibility : DockerRemoteMachineBasedTest() {
 				.withCordapp(modernCiV1)
 				.withCordapp(freighterHelperCordapp)
 				.withDatabase(machineProvider.requestDatabase(db))
-		).withVersion("4.3")
+		).withVersion(DeploymentVersion(testCordaReleaseVersion, false))
 			.deploy(deploymentContext)
 
 		val nodeMachine = deploymentResult.getOrThrow().nodeMachines.single()

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,13 @@ group=com.r3.corda.sdk.token
 version=0.1
 kotlin.incremental=false
 org.gradle.caching=false
+
+kotlin_version=1.2.71
+dokka_version=0.9.17
+corda_gradle_plugins_version=5.0.14
+
+quasar_version=0.7.13_r3
+freighter_version=0.7.7-SNAPSHOT
+
+artifactory_version=4.21.0
+artifactory_contextUrl=https://software.r3.com/artifactory

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.6-all.zip
+distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/contracts-for-testing/build.gradle
+++ b/modules/contracts-for-testing/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'net.corda.plugins.cordapp'
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'net.corda.plugins.cordapp'
+}
 
 cordapp {
     targetPlatformVersion 4
@@ -32,9 +35,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Corda dependencies.
-    cordaCompile ("$corda_release_group:corda-core:$corda_release_version"){
-        changing = true
-    }
+    cordaCompile "$corda_release_group:corda-core:$corda_release_version"
 
     // Logging.
     testCompile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"

--- a/modules/selection/build.gradle
+++ b/modules/selection/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'net.corda.plugins.cordapp'
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'net.corda.plugins.cordapp'
+}
 
 cordapp {
     targetPlatformVersion 4
@@ -32,13 +35,8 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Corda dependencies.
-    cordaCompile ("$corda_release_group:corda-core:$corda_release_version"){
-        changing = true
-    }
-    // Corda dependencies.
-    cordaCompile ("$corda_release_group:corda-node-api:$corda_release_version"){
-        changing = true
-    }
+    cordaCompile "$corda_release_group:corda-core:$corda_release_version"
+    cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
 
     // Logging.
     testCompile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
@@ -52,6 +50,6 @@ dependencies {
     cordapp project(":contracts")
 }
 
-jar {
-    baseName "tokens-selection"
+tasks.named('jar', Jar) {
+    archiveBaseName = 'tokens-selection'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,20 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+        id 'org.jetbrains.dokka' version dokka_version
+        id 'org.jetbrains.kotlin.plugin.jpa' version kotlin_version
+        id 'org.jetbrains.kotlin.plugin.allopen' version kotlin_version
+        id 'net.corda.plugins.cordformation' version corda_gradle_plugins_version
+        id 'net.corda.plugins.cordapp' version corda_gradle_plugins_version
+        id 'net.corda.plugins.quasar-utils' version corda_gradle_plugins_version
+        id 'com.jfrog.artifactory' version artifactory_version
+    }
+}
+
 include 'contracts'
 include 'workflows'
 include 'modules:contracts-for-testing'

--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -1,11 +1,10 @@
-apply plugin: 'kotlin-jpa'
-apply plugin: 'net.corda.plugins.quasar-utils'
-apply plugin: 'net.corda.plugins.cordapp'
-
-
-evaluationDependsOn(":modules:selection")
-
-def selectionProject = project(":modules:selection")
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.kotlin.plugin.jpa'
+    id 'org.jetbrains.kotlin.plugin.allopen'
+    id 'net.corda.plugins.quasar-utils'
+    id 'net.corda.plugins.cordapp'
+}
 
 cordapp {
     targetPlatformVersion 5
@@ -42,12 +41,13 @@ sourceSets {
 }
 
 configurations {
+    compileClasspath {
+        attributes { attr ->
+            attr.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+        }
+    }
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
-}
-
-compileKotlin{
-    dependsOn (selectionProject.jar)
 }
 
 dependencies {
@@ -55,13 +55,8 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Corda dependencies.
-    cordaCompile("$corda_release_group:corda-core:$corda_release_version") {
-        changing = true
-    }
-
-    cordaCompile("$corda_release_group:corda-node-api:$corda_release_version") {
-        changing = true
-    }
+    cordaCompile "$corda_release_group:corda-core:$corda_release_version"
+    cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
 
     // Logging.
     testCompile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
@@ -74,7 +69,7 @@ dependencies {
     // CorDapp dependencies.
     cordapp project(":contracts")
 
-    compile(files(selectionProject.jar.archivePath))
+    compile project(':modules:selection')
 
     //CI for confidential tokens
     cordapp "$confidential_id_release_group:ci-workflows:$confidential_id_release_version"
@@ -83,15 +78,15 @@ dependencies {
     compileOnly project(":modules:contracts-for-testing")
     testCompile project(":modules:contracts-for-testing")
 
-    compileOnly("org.postgresql:postgresql:42.2.8")
+    compileOnly "org.postgresql:postgresql:42.2.8"
 
 }
 
-task integrationTest(type: Test, dependsOn: []) {
+tasks.register('integrationTest', Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
-jar {
-    baseName "tokens-workflows"
+tasks.named('jar', Jar) {
+    archiveBaseName = 'tokens-workflows'
 }

--- a/workflows/src/integrationTest/kotlin/com/r3/corda/lib/tokens/integrationTest/TokenDriverTest.kt
+++ b/workflows/src/integrationTest/kotlin/com/r3/corda/lib/tokens/integrationTest/TokenDriverTest.kt
@@ -48,7 +48,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.equalTo
-import org.junit.Assert
+import org.hamcrest.MatcherAssert
 import org.junit.Test
 import kotlin.test.assertFailsWith
 
@@ -82,8 +82,8 @@ class TokenDriverTest {
             issuer.rpc.startFlowDynamic(IssueTokens::class.java, listOf(tokenToIssueToIssuer, tokenToIssueToOther), emptyList<Party>()).returnValue.getOrThrow()
             val queryResult = issuer.rpc.vaultQueryByCriteria(heldTokenAmountCriteria(customToken, issuerParty), FungibleToken::class.java)
 
-            Assert.assertThat(queryResult.states.size, `is`(1))
-            Assert.assertThat(queryResult.states.first().state.data.holder, `is`(equalTo((issuerParty as AbstractParty))))
+            MatcherAssert.assertThat(queryResult.states.size, `is`(1))
+            MatcherAssert.assertThat(queryResult.states.first().state.data.holder, `is`(equalTo((issuerParty as AbstractParty))))
 
         }
     }
@@ -119,8 +119,8 @@ class TokenDriverTest {
 
             val queryResult = issuer.rpc.vaultQueryByCriteria(heldTokenAmountCriteria(customToken, newCi1), FungibleToken::class.java)
 
-            Assert.assertThat(queryResult.states.size, `is`(1))
-            Assert.assertThat(queryResult.states.first().state.data.holder, `is`(equalTo((newCi1 as AbstractParty))))
+            MatcherAssert.assertThat(queryResult.states.size, `is`(1))
+            MatcherAssert.assertThat(queryResult.states.first().state.data.holder, `is`(equalTo((newCi1 as AbstractParty))))
 
         }
     }

--- a/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/LedgerTestWithPersistence.kt
+++ b/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/LedgerTestWithPersistence.kt
@@ -3,11 +3,11 @@ package com.r3.corda.lib.tokens.workflows
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.node.services.IdentityService
+import net.corda.coretesting.internal.rigorousMock
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.core.TestIdentity
-import net.corda.testing.internal.rigorousMock
 import net.corda.testing.node.MockServices
 import org.junit.Rule
 import org.mockito.Mockito

--- a/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/RedeemTokenTestsFlow.kt
+++ b/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/RedeemTokenTestsFlow.kt
@@ -10,8 +10,12 @@ import com.r3.corda.lib.tokens.contracts.utilities.of
 import com.r3.corda.lib.tokens.money.BTC
 import com.r3.corda.lib.tokens.money.GBP
 import com.r3.corda.lib.tokens.selection.InsufficientBalanceException
-import com.r3.corda.lib.tokens.testing.states.Appartment
-import com.r3.corda.lib.tokens.workflows.flows.rpc.*
+import com.r3.corda.lib.tokens.workflows.flows.rpc.ConfidentialIssueTokens
+import com.r3.corda.lib.tokens.workflows.flows.rpc.ConfidentialMoveFungibleTokens
+import com.r3.corda.lib.tokens.workflows.flows.rpc.ConfidentialMoveNonFungibleTokens
+import com.r3.corda.lib.tokens.workflows.flows.rpc.IssueTokens
+import com.r3.corda.lib.tokens.workflows.flows.rpc.RedeemFungibleTokens
+import com.r3.corda.lib.tokens.workflows.flows.rpc.RedeemNonFungibleTokens
 import com.r3.corda.lib.tokens.workflows.types.PartyAndAmount
 import com.r3.corda.lib.tokens.workflows.types.PartyAndToken
 import com.r3.corda.lib.tokens.workflows.utilities.heldBy
@@ -81,7 +85,7 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty
 
         // Redeeming the tokens.
         val amountToRedeem = 10.GBP
@@ -114,7 +118,7 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty
 
         // Redeeming the tokens.
         nodeA.startFlow(RedeemNonFungibleTokens(myTokenType, issuer))
@@ -144,7 +148,7 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty
 
         // Redeeming the tokens.
         nodeA.startFlow(RedeemNonFungibleTokens(myTokenType, issuer))
@@ -164,7 +168,7 @@ class RedeemTokenTestsFlow{
         val issuer: Party = nodeI.legalIdentity()
         val holder: Party = nodeA.legalIdentity()
 
-        val myTokenType: TokenType = TokenType(tokenIdentifier = "TEST", fractionDigits = 2)
+        val myTokenType = TokenType(tokenIdentifier = "TEST", fractionDigits = 2)
         // Creating an instance of IssuedTokenType with GBP token type and nodeI as issuer.
         val myIssuedTokenType: IssuedTokenType = myTokenType issuedBy issuer
 
@@ -179,7 +183,7 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.tokenAmountsByToken(myTokenType).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.tokenAmountsByToken(myTokenType).states).isNotEmpty
 
         // Redeeming the tokens.
         nodeA.startFlow(RedeemFungibleTokens(amount = 10 of myTokenType, issuer = issuer))
@@ -195,7 +199,7 @@ class RedeemTokenTestsFlow{
         val issuer: Party = nodeI.legalIdentity()
         val holder: Party = nodeA.legalIdentity()
 
-        val myTokenType: TokenType = TokenType(tokenIdentifier = "TEST", fractionDigits = 2)
+        val myTokenType = TokenType(tokenIdentifier = "TEST", fractionDigits = 2)
         // Creating an instance of IssuedTokenType with myTokenType token type and nodeI as issuer.
         val myIssuedTokenType: IssuedTokenType = myTokenType issuedBy issuer
 
@@ -215,8 +219,8 @@ class RedeemTokenTestsFlow{
         nodeI.startFlow(IssueTokens(listOf(fungibleToken, btcFungibleToken)))
         network.runNetwork()
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.tokenAmountsByToken(myTokenType).states).isNotEmpty()
-        assertThat(nodeA.services.vaultService.tokenAmountsByToken(BTC).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.tokenAmountsByToken(myTokenType).states).isNotEmpty
+        assertThat(nodeA.services.vaultService.tokenAmountsByToken(BTC).states).isNotEmpty
         // Redeeming the myTokenType tokens.
         nodeA.startFlow(RedeemFungibleTokens(amount = 10 of myTokenType, issuer = issuer))
         network.runNetwork()
@@ -249,8 +253,8 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty()
-        assertThat(nodeB.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty
+        assertThat(nodeB.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty
 
         // Redeeming the tokens.
         val amountToRedeem = 10.GBP
@@ -281,7 +285,7 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty
         assertThat(nodeI.services.vaultService.tokenAmountsByToken(GBP).states).isEmpty()
 
         // Redeeming the tokens.
@@ -309,8 +313,8 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty()
-        assertThat(nodeB.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty
+        assertThat(nodeB.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty
         assertNotEquals(nodeA.services.vaultService.tokenAmountsByToken(GBP).states.single().state.data.holder, nodeA.legalIdentity())
 
         // Redeeming the tokens.
@@ -340,14 +344,14 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty
 
         // Moving tokens to holder2.
         nodeA.startFlow(ConfidentialMoveFungibleTokens(PartyAndAmount(holder2,10.GBP), listOf(issuer)))
         network.runNetwork()
 
         // Checking if the tokens are moved to nodeB.
-        assertThat(nodeB.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty()
+        assertThat(nodeB.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty
         assertNotEquals(nodeB.services.vaultService.tokenAmountsByToken(GBP).states.single().state.data.holder, nodeB.legalIdentity())
         assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isEmpty()
 
@@ -377,7 +381,7 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.tokenAmountsByToken(GBP).states).isNotEmpty
 
         // Redeeming the tokens.
         val amountToRedeem = 40.GBP
@@ -408,7 +412,7 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the tokens are issued to nodeA.
-        assertThat(nodeA.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty
 
         // Redeeming the tokens.
         nodeA.startFlow(RedeemNonFungibleTokens(myTokenType, issuer))
@@ -439,7 +443,7 @@ class RedeemTokenTestsFlow{
         network.runNetwork()
 
         // Checking if the token is issued to nodeA.
-        assertThat(nodeA.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty()
+        assertThat(nodeA.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty
 
         // Moving tokens to holder2.
         nodeA.startFlow(ConfidentialMoveNonFungibleTokens(PartyAndToken(holder2,myTokenType), listOf(issuer)))
@@ -447,7 +451,7 @@ class RedeemTokenTestsFlow{
 
         // Checking if the token is moved to nodeB.
         assertThat(nodeA.services.vaultService.heldTokensByToken(myTokenType).states).isEmpty()
-        assertThat(nodeB.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty()
+        assertThat(nodeB.services.vaultService.heldTokensByToken(myTokenType).states).isNotEmpty
 
         // Redeeming the tokens.
         nodeB.startFlow(RedeemNonFungibleTokens(myTokenType, issuer))

--- a/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/VaultWatcherServiceTest.kt
+++ b/workflows/src/test/kotlin/com/r3/corda/lib/tokens/workflows/VaultWatcherServiceTest.kt
@@ -39,9 +39,8 @@ import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.InternalMockNodeParameters
 import net.corda.testing.node.internal.startFlow
 import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers.greaterThanOrEqualTo
-import org.hamcrest.Matchers.isIn
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
@@ -53,6 +52,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+import org.hamcrest.Matchers.`in`
 
 class VaultWatcherServiceTest {
     private lateinit var services: MockServices
@@ -80,7 +80,7 @@ class VaultWatcherServiceTest {
         val amountToIssue: Long = 100
         val stateAndRef = createNewFiatCurrencyTokenRef(amountToIssue, owner, notary1, issuer1, GBP, observable, database)
         val selectedTokens = vaultWatcherService.selectTokens(Holder.KeyIdentity(owner), Amount(5, GBP), selectionId = "abc")
-        Assert.assertThat(selectedTokens, `is`(equalTo(listOf(stateAndRef))))
+        MatcherAssert.assertThat(selectedTokens, `is`(equalTo(listOf(stateAndRef))))
     }
 
     @Test
@@ -95,7 +95,7 @@ class VaultWatcherServiceTest {
         }
 
         val selectedTokens = vaultWatcherService.selectTokens(Holder.KeyIdentity(owner), Amount(45, GBP), selectionId = "abc")
-        Assert.assertThat(selectedTokens.map { it.state.data.amount.quantity }.sumByLong { it }, `is`(greaterThanOrEqualTo(45L)))
+        MatcherAssert.assertThat(selectedTokens.map { it.state.data.amount.quantity }.sumByLong { it }, `is`(greaterThanOrEqualTo(45L)))
     }
 
     @Test(expected = InsufficientBalanceException::class)
@@ -110,7 +110,7 @@ class VaultWatcherServiceTest {
         val stateAndRef = createNewFiatCurrencyTokenRef(amountToIssue, owner, notary1, issuer1, GBP, observable, database)
 
         val selectedTokens = vaultWatcherService.selectTokens(Holder.TokenOnly(), Amount(5, IssuedTokenType(issuer1, GBP)), selectionId = "abc")
-        Assert.assertThat(selectedTokens, `is`(equalTo(listOf<StateAndRef<FungibleToken>>(stateAndRef))))
+        MatcherAssert.assertThat(selectedTokens, `is`(equalTo(listOf(stateAndRef))))
         vaultWatcherService.selectTokens(Holder.KeyIdentity(owner), Amount(5, IssuedTokenType(issuer1, GBP)), selectionId = "abc")
     }
 
@@ -133,13 +133,13 @@ class VaultWatcherServiceTest {
             it.state.notary == notary1
         }, selectionId = "abc")
 
-        Assert.assertThat(selectedTokens, `is`(equalTo(listOf<StateAndRef<FungibleToken>>(stateAndRef))))
+        MatcherAssert.assertThat(selectedTokens, `is`(equalTo(listOf(stateAndRef))))
 
         val notary2Selected = vaultWatcherService.selectTokens(Holder.KeyIdentity(owner), Amount(amountToIssue * 2, GBP), {
             it.state.notary == notary2
         }, selectionId = "abc")
 
-        Assert.assertThat(notary2Selected, `is`(equalTo(notary2Selected.filter { it.state.notary == notary2 })))
+        MatcherAssert.assertThat(notary2Selected, `is`(equalTo(notary2Selected.filter { it.state.notary == notary2 })))
     }
 
     @Test
@@ -165,7 +165,7 @@ class VaultWatcherServiceTest {
 
         val selectedTokensAfterSpend = vaultWatcherService.selectTokens(Holder.KeyIdentity(owner), Amount(10000000000, GBP), allowShortfall = true, selectionId = "abc")
 
-        Assert.assertThat(spentInputs, everyItem(not(isIn(selectedTokensAfterSpend))))
+        MatcherAssert.assertThat(spentInputs, everyItem(`is`(not(`in`(selectedTokensAfterSpend)))))
     }
 
     @Test
@@ -185,7 +185,7 @@ class VaultWatcherServiceTest {
 
         val selectedTokensAfterSpend = vaultWatcherService.selectTokens(Holder.KeyIdentity(owner), Amount(10000000000, GBP), allowShortfall = true, selectionId = "abc")
 
-        Assert.assertThat(selectedTokens, everyItem(not(isIn(selectedTokensAfterSpend))))
+        MatcherAssert.assertThat(selectedTokens, everyItem(`is`(not(`in`(selectedTokensAfterSpend)))))
     }
 
     @Test
@@ -239,7 +239,7 @@ class VaultWatcherServiceTest {
             val account = accountsAndKeyEntry.key
             val selectedTokens = vaultWatcherService.selectTokens(Holder.MappedIdentity(account), Amount(10000000000, GBP), allowShortfall = true, selectionId = "CHEESEY_BITES").sortedBy { it.toString() }
             val expectedTokens = accountToIssuedTokensMap[account]!!.sortedBy { it.toString() }
-            Assert.assertThat(selectedTokens, `is`(equalTo(expectedTokens)))
+            MatcherAssert.assertThat(selectedTokens, `is`(equalTo(expectedTokens)))
             expectedTokens.forEach {
                 vaultWatcherService.unlockToken(it, "CHEESEY_BITES")
             }
@@ -250,7 +250,7 @@ class VaultWatcherServiceTest {
             val key = keyToTokenEntry.key
             val selectedTokens = vaultWatcherService.selectTokens(Holder.KeyIdentity(key), Amount(10000000000, GBP), allowShortfall = true, selectionId = "CHEESEY_BITES").sortedBy { it.toString() }
             val expectedTokens = listOf(keyToTokenEntry.value)
-            Assert.assertThat(selectedTokens, `is`(equalTo(expectedTokens)))
+            MatcherAssert.assertThat(selectedTokens, `is`(equalTo(expectedTokens)))
         }
     }
 
@@ -398,7 +398,7 @@ class VaultWatcherServiceTest {
         gbpSpendFuture2.getOrThrow()
 
 
-        Assert.assertThat(spendTracker.filter { it.value.get() > 1 }.toList(), `is`(equalTo(emptyList())))
+        MatcherAssert.assertThat(spendTracker.filter { it.value.get() > 1 }.toList(), `is`(equalTo(emptyList())))
     }
 
     @Test
@@ -427,7 +427,7 @@ class VaultWatcherServiceTest {
             mockNet.runNetwork()
             val selectedToken = tokensFuture.getOrThrow().single()
 
-            Assert.assertThat(issuedStateRef, `is`(equalTo(selectedToken)))
+            MatcherAssert.assertThat(issuedStateRef, `is`(equalTo(selectedToken)))
         }finally {
             mockNet.stopNodes()
         }


### PR DESCRIPTION
Bring Token SDK up to Corda 4.5 as a first step, Moving onwards to Corda 4.6, 4.7 and 4.8 looks more problematic, and so will be done separately.

Also apply the `org.jetbrains.kotlin.plugin.allopen` plugin to the CorDapps to ensure that all JPA entities are non-final, i.e. can be proxied, and fix build errors due to `money` being refactored.

## _This PR is descoped until someone decides to take ownership of the `token-sdk` repository again._