### PR TITLE
open class NonFungibleTokenContract

### DIFF
--- a/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/NonFungibleTokenContract.kt
+++ b/contracts/src/main/kotlin/com/r3/corda/lib/tokens/contracts/NonFungibleTokenContract.kt
@@ -12,7 +12,7 @@ import java.security.PublicKey
 /**
  * See kdoc for [FungibleTokenContract].
  */
-class NonFungibleTokenContract : AbstractTokenContract<NonFungibleToken>() {
+open class NonFungibleTokenContract : AbstractTokenContract<NonFungibleToken>() {
 
     override val accepts: Class<NonFungibleToken> get() = uncheckedCast(NonFungibleToken::class.java)
 


### PR DESCRIPTION
Even though the FungibleTokenContract class is open public, the NonFungibleTokenContract class is not, so it cannot be inherited. Correct me if I misunderstand the difference.