### PR TITLE
INFRA-2059: use correct snyk location on server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         LOOPBACK_ADDRESS = "172.17.0.1"
         DOCKER_CREDENTIALS = credentials('docker-for-oracle-login')
         MAVEN_LOCAL_PUBLISH = "${env.WORKSPACE}/${mavenLocal}"
-        SNYK_TOKEN  = credentials("c4-sdk-snyk")
+        SNYK_TOKEN = credentials('c4-ent-snyk-api-token-secret')
     }
 
     parameters {


### PR DESCRIPTION
use correct credentials ID so as snyk scans get promoted to the Ent location of the snyk server (previously pushing data to C4 OS org which was incorrect)