### PR TITLE
INFRA-2098: Adding --remote-repo-url to group on Snyk UI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
                     // Invoke Snyk for each Gradle sub project we wish to scan
                     def modulesToScan = ['contracts', 'workflows']
                     modulesToScan.each { module ->
-                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --remote-repo-url=https://github.com/corda/token-sdk.git --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'", false, true)
+                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --remote-repo-url='${env.GIT_URL}' --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'", false, true)
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
                     // Invoke Snyk for each Gradle sub project we wish to scan
                     def modulesToScan = ['contracts', 'workflows']
                     modulesToScan.each { module ->
-                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'", false, true)
+                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --remote-repo-url=https://github.com/corda/token-sdk.git --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'", false, true)
                     }
                 }
             }


### PR DESCRIPTION
Adding the following allows the project to be corretly grouped on the Snyk servrer as seen in the attached image. 

It also allows the target id to be resolvable for snyk deleter/snyk license generator jobs which require remote-url configured. 

![image](https://user-images.githubusercontent.com/100574906/229144187-068fdc4d-7973-4ee2-b28c-b1f680d45840.png)
