### PR TITLE
ES-770: Update Jenkinsfile to add cron to build project regularly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     options { timestamps() }
 
     triggers {
-        cron (isReleaseBranch ? 'H 0 * * 1,4' : '')
+        cron (isReleaseBranch() ? 'H 0 * * 1,4' : '')
     }
 
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,10 @@ pipeline {
 
     options { timestamps() }
 
+    triggers {
+        cron (isReleaseBranch ? 'H 0 * * 1,4' : '')
+    }
+
     environment {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"


### PR DESCRIPTION
Add a cron job to this Jenkins file.

Build this project twice a week, Monday and Thursday, at a random minute (H) in the hour of midnight to distribute load.

While this project is supported, there is not a lot of activity here, This change is to avoid situations where this project is not built for weeks/ months and build issues are only discovered on a release day.