### PR TITLE
ES-2125: fix Jenkins logic issue causing gitID to be appended to version in release builds 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def isReleaseBranch() {
 }
 
 def isRelease = isReleaseTag() || isReleaseCandidate()
-String publishOptions = isReleaseBranch() ? "-s --info" : "--no-daemon -s -PversionFromGit"
+String publishOptions = (isReleaseBranch() | isRelease) ? "-s --info" : "--no-daemon -s -PversionFromGit"
 
 pipeline {
     agent { label 'standard' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def isReleaseBranch() {
 }
 
 def isRelease = isReleaseTag() || isReleaseCandidate()
-String publishOptions = (isReleaseBranch() | isRelease) ? "-s --info" : "--no-daemon -s -PversionFromGit"
+String publishOptions = (isReleaseBranch() || isRelease) ? "-s --info" : "--no-daemon -s -PversionFromGit"
 
 pipeline {
     agent { label 'standard' }


### PR DESCRIPTION

Fix Jenkins logic issue discovered during the release process.

Previous logic is incorrect as it would result in artifacts from tag builds being versioning with a git commit hash suffix.
i.e. 1.4-RC04-<CommitID>. This should never be used for tag builds.

Updated logic ensures that the git suffix is only used for PRs or feature branches.

Note: not blocking the current release, I've made the needed changes directly on the tag, but this should go back to the release branch to ensure no issues on later releases.

The same issue was also fixed in the following locations:
- https://github.com/corda/r3-libs/pull/17
- https://github.com/corda/confidential-identities/pull/35
- https://github.com/corda/ledger-graph/pull/108
