### PR TITLE
ENT-11663: Depend on SNAPSHOT version of Corda for early testing.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12-HC04'
+        corda_release_version = '4.12-SNAPSHOT'
         confidential_id_release_group = "com.r3.corda.lib.ci"
         confidential_id_release_version = "1.2-HC04"
 


### PR DESCRIPTION
ENT-11663: Depend on SNAPSHOT version of Corda for early testing.