### PR TITLE
ENT-11709,ENT-10933,ENT-11694,ENT-11693,ENT-11531,ENT-10971,ENT-10970,ENT-10972,ENT-10973,ENT-10969,ENT-11482,ENT-10924 - Security updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12-RC01'
+        corda_release_version = '4.12-SNAPSHOT'
         confidential_id_release_group = "com.r3.corda.lib.ci"
         confidential_id_release_version = "1.2-RC01"
 
@@ -20,6 +20,7 @@ buildscript {
         aetherVersion = '1.0.0.v20140518'
         mavenVersion = '3.1.0'
         maven_resolver_version = "1.1.1"
+        snake_yaml_version = '2.2'
         warnings_as_errors = project.hasProperty("compilation.warningsAsErrors") ? project.property("compilation.warningsAsErrors").toBoolean() : true
 
         test_module_opens = [
@@ -93,6 +94,7 @@ allprojects {
             // Force dependencies to use the same version of Kotlin
             force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
             cacheChangingModulesFor 0, 'seconds'
+            force "org.yaml:snakeyaml:$snake_yaml_version"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12-SNAPSHOT'
+        corda_release_version = '4.12-RC01'
         confidential_id_release_group = "com.r3.corda.lib.ci"
         confidential_id_release_version = "1.2-RC01"
 

--- a/workflows-integration-test/build.gradle
+++ b/workflows-integration-test/build.gradle
@@ -71,7 +71,7 @@ dependencies {
 
     implementation project(":modules:contracts-for-testing")
     implementation project(":modules:selection")
-    implementation "org.postgresql:postgresql:42.2.8"
+    implementation "org.postgresql:postgresql:42.7.3"
     implementation "org.slf4j:slf4j-api:$slf4j_version"
 
     testImplementation project(":modules:contracts-for-testing")

--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation "org.liquibase:liquibase-core:$liquibase_version"
     implementation "org.hibernate:hibernate-core:$hibernate_version"
     implementation "com.google.guava:guava:$guava_version"
-    implementation "org.postgresql:postgresql:42.2.8"
+    implementation "org.postgresql:postgresql:42.7.3"
     implementation(files(selectionProject.jar.archivePath))
 
     runtimeOnly "org.iq80.snappy:snappy:$snappy_version"


### PR DESCRIPTION
Updates to address security vulnerabilities reported in the Corda 4.12 release pack.
Many issues are resolved merely by building against the latest Corda Ent 4.12 (snapshot in this PR, which will become 4.12-RC02 in due course).