### PR TITLE
ES-2458: 4.12 GA post release actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12-RC02'
+        corda_release_version = '4.12'
         confidential_id_release_group = "com.r3.corda.lib.ci"
-        confidential_id_release_version = "1.2-RC02"
+        confidential_id_release_version = "1.2"
 
         corda_gradle_plugins_version = '5.1.1'
         snappy_version = '0.4'


### PR DESCRIPTION
Post Release actions - Pin internal dependencies to GA versions. Please note these versions have already been released via tag creation but this PR is now committing the needed changes back to the release branch.