### PR TITLE
ES-2505: do not hardcode Artifactory credentials in the source code

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* removed direct use of a cache repository for Gradle via Artifactory, it is no longer needed