### PR TITLE
ENT-12080 jcenter retirement (#272)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,13 +39,14 @@ buildscript {
     }
 
     repositories {
-        jcenter()
         mavenCentral()
         mavenLocal()
 
         maven { url "${publicArtifactURL}/corda-releases" }
         maven { url "${publicArtifactURL}/corda-dependencies" }
         maven { url "https://repo.gradle.org/gradle/libs-releases-local/" }
+        // as last resort, check our backup of now defunc JCenter repo
+        maven { url "${publicArtifactURL}/jcenter-backup" }
 
         maven {
             url "${artifactoryContextUrl}/corda-dev"
@@ -101,7 +102,6 @@ allprojects {
 
 subprojects {
     repositories {
-        jcenter()
         mavenCentral()
         mavenLocal()
         maven { url 'https://jitpack.io' }
@@ -130,6 +130,9 @@ subprojects {
                 password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
             }
         }
+        maven { url "${publicArtifactURL}/corda-dependencies" }
+        // as last resort, check our backup of now defunc JCenter repo
+        maven { url "${publicArtifactURL}/jcenter-backup" }
     }
 
     apply plugin: 'org.jetbrains.kotlin.jvm'


### PR DESCRIPTION
* ENT-12080 jcenter retirement

* ENT-12080 jcenter retirement - revert accidental change to Corda version

* ENT-12080 jcenter retirement

* moved JCenter backup repo to end of the list of repositories

---------

Co-authored-by: Waldemar Zurowski <waldemar.zurowski@r3.com>

(cherry picked from commit 749483f691c2c6ca56d9caacdd73a9e6319a969e)