### PR TITLE
ENT-12428,ENT-12430 - Dependency update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12'
+        corda_release_version = '4.12.4-RC01'
         confidential_id_release_group = "com.r3.corda.lib.ci"
         confidential_id_release_version = "1.2"
 


### PR DESCRIPTION
Updated to build against Corda 4.12.4, which fixes a security vulnerability.