### PR TITLE
ENT-12854 - Updated dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         corda_release_group = 'net.corda'
         corda_release_version = '4.12.4-RC01'
         confidential_id_release_group = "com.r3.corda.lib.ci"
-        confidential_id_release_version = "1.2"
+        confidential_id_release_version = "1.2.7"
 
-        corda_gradle_plugins_version = '5.1.1'
+        corda_gradle_plugins_version = '5.1.3'
         snappy_version = '0.4'
         kotlin_version = '1.9.0'
         junit_version = '4.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ internalPublishVersion=1.+
 # additional dependencies
 rxjava_version=1.3.8
 slf4j_version=2.0.12
-quasar_version=0.9.0_r3
+quasar_version=0.9.1_r3
 liquibase_version=4.20.0
 hibernate_version=5.6.14.Final
 guava_version=33.1.0-jre


### PR DESCRIPTION
Updated some dependencies.
Those latest dependencies can be built outside of R3. In order for tokens-sdk to also be built outside of R3 it must depend on those versions.