### PR TITLE
ENT-12854 - Updated Corda version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12.4-RC01'
+        corda_release_version = '4.12.5'
         confidential_id_release_group = "com.r3.corda.lib.ci"
         confidential_id_release_version = "1.2.7"
 


### PR DESCRIPTION
Updated Corda version to a released version. Missed this with the previous dependency updates.