### PR TITLE
ENT-15968 : Upgrading corda_release_version with the snapshot version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,10 @@ def isReleaseBranch() {
     return (env.BRANCH_NAME =~ /^release\/.*$/)
 }
 
+def isSnykBranch() {
+    return (env.BRANCH_NAME =~ /^snyk\/release\/.*$/)
+}
+
 def isRelease = isReleaseTag() || isReleaseCandidate()
 String publishOptions = (isReleaseBranch() || isRelease) ? "-s --info" : "--no-daemon -s -PversionFromGit"
 
@@ -63,7 +67,7 @@ pipeline {
 
         stage('Snyk Security') {
             when {
-                expression { isReleaseTag() || isReleaseBranch() }
+                expression { isReleaseTag() || isReleaseBranch() || isSnykBranch() }
             }
             steps {
                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,8 @@ def isReleaseBranch() {
 }
 
 def isSnykBranch() {
-    return (env.BRANCH_NAME =~ /^snyk\/release\/.*$/)
+    def branch = env.CHANGE_BRANCH ?: env.BRANCH_NAME
+    return (branch =~ /^snyk\/release\/.*$/)
 }
 
 def isRelease = isReleaseTag() || isReleaseCandidate()

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12.5'
+        corda_release_version = '4.12.SNAPSHOT'
         confidential_id_release_group = "com.r3.corda.lib.ci"
         confidential_id_release_version = "1.2.7"
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12.SNAPSHOT'
+        corda_release_version = '4.12-SNAPSHOT'
         confidential_id_release_group = "com.r3.corda.lib.ci"
         confidential_id_release_version = "1.2.7"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,6 @@ quasar_version=0.9.1_r3
 liquibase_version=4.20.0
 hibernate_version=5.6.14.Final
 guava_version=33.1.0-jre
-assertj_version=3.12.2
+assertj_version=3.27.7
 mockito_kotlin_version=4.1.0
 typesafe_config_version=1.3.4


### PR DESCRIPTION
This PR updates corda_release_version with the latest 4.12.snapshot version.

Also I have added a new condition that allows to execute snyk scan in pipeline when it is a snyk branch(starts with snyk/release/) 