### PR TITLE
ENT-15974 : upgrade assertJ version to 3.27.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,6 @@ quasar_version=0.9.1_r3
 liquibase_version=4.20.0
 hibernate_version=5.6.14.Final
 guava_version=33.1.0-jre
-assertj_version=3.12.2
+assertj_version=3.27.7
 mockito_kotlin_version=4.1.0
 typesafe_config_version=1.3.4


### PR DESCRIPTION
This PR upgrades assertJ version from 3.12.2 to 3.27.7