### PR TITLE
ENT-15973 : forced upgrade netty version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,19 @@ allprojects {
             force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
             cacheChangingModulesFor 0, 'seconds'
             force "org.yaml:snakeyaml:$snake_yaml_version"
+
+            eachDependency { details ->
+                // SNYK-JAVA-IONETTY-18170211 / CVE-2026-55851
+                // SNYK-JAVA-IONETTY-18233122 / CVE-2026-59919
+                // Vulnerability in io.netty:netty-codec-haproxy, which is a transitive dependency
+                if (details.requested.group == 'io.netty' && details.requested.name.startsWith('netty-')) {
+                    if (details.requested.name.startsWith('netty-tcnative')) {
+                        details.useVersion tcnative_version
+                    } else {
+                        details.useVersion netty_version
+                    }
+                }
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,5 @@ guava_version=33.1.0-jre
 assertj_version=3.12.2
 mockito_kotlin_version=4.1.0
 typesafe_config_version=1.3.4
+netty_version=4.1.136.Final
+tcnative_version=2.0.74.Final


### PR DESCRIPTION
Forced upgrade netty to resolve the following vulnerabilities : CVE-2026-55851, CVE-2026-59919.